### PR TITLE
Add exercise management pages

### DIFF
--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -130,3 +130,46 @@ export async function fetchLessonPreview(cw_id) {
   const resp = await api.get(`/teacher/lesson/preview/${cw_id}`);
   return resp.data;  // 返回课件详细信息
 }
+
+/**
+ * 获取练习列表
+ * @returns {Promise<Array>} 练习列表
+ */
+export async function fetchExerciseList() {
+  const resp = await api.get("/teacher/exercise/list");
+  return resp.data;
+}
+
+/**
+ * 获取练习预览
+ * @param {number} ex_id - 练习 ID
+ * @returns {Promise<Object>} 练习详细信息
+ */
+export async function fetchExercisePreview(ex_id) {
+  const resp = await api.get(`/teacher/exercise/preview/${ex_id}`);
+  return resp.data;
+}
+
+/**
+ * 下载已保存练习的题目 PDF
+ * @param {number} ex_id - 练习 ID
+ * @returns {Promise<Blob>} PDF 二进制
+ */
+export async function downloadExerciseQuestionsPdf(ex_id) {
+  const resp = await api.get(`/teacher/exercise/${ex_id}/download/questions`, {
+    responseType: "blob",
+  });
+  return resp.data;
+}
+
+/**
+ * 下载已保存练习的答案 PDF
+ * @param {number} ex_id - 练习 ID
+ * @returns {Promise<Blob>} PDF 二进制
+ */
+export async function downloadExerciseAnswersPdf(ex_id) {
+  const resp = await api.get(`/teacher/exercise/${ex_id}/download/answers`, {
+    responseType: "blob",
+  });
+  return resp.data;
+}

--- a/frontend/src/pages/ExerciseList.jsx
+++ b/frontend/src/pages/ExerciseList.jsx
@@ -1,0 +1,62 @@
+// src/pages/ExerciseList.jsx
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { fetchExerciseList } from "../api/teacher";
+import "../index.css";
+
+export default function ExerciseList() {
+  const [exercises, setExercises] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const list = await fetchExerciseList();
+        setExercises(list);
+      } catch (err) {
+        setError("加载练习列表失败，请稍后重试");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h2>我的练习列表</h2>
+        {error && <div className="error">{error}</div>}
+        {loading ? (
+          <div>加载中...</div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>主题</th>
+                <th>创建时间</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {exercises.map((ex) => (
+                <tr key={ex.id}>
+                  <td>{ex.id}</td>
+                  <td>{ex.subject}</td>
+                  <td>{ex.created_at}</td>
+                  <td>
+                    <Link to={`/teacher/exercise/preview/${ex.id}`}>预览</Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ExercisePreview.jsx
+++ b/frontend/src/pages/ExercisePreview.jsx
@@ -1,0 +1,145 @@
+// src/pages/ExercisePreview.jsx
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  fetchExercisePreview,
+  downloadExerciseQuestionsPdf,
+  downloadExerciseAnswersPdf,
+  assignExercise,
+} from "../api/teacher";
+import "../index.css";
+
+export default function ExercisePreview() {
+  const { ex_id } = useParams();
+  const navigate = useNavigate();
+  const [exercise, setExercise] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [assigning, setAssigning] = useState(false);
+  const [assigned, setAssigned] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await fetchExercisePreview(ex_id);
+        setExercise(data);
+      } catch (err) {
+        setError("加载预览失败，请稍后重试");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [ex_id]);
+
+  const handleDownloadQ = async () => {
+    if (!exercise) return;
+    setDownloading(true);
+    try {
+      const blob = await downloadExerciseQuestionsPdf(ex_id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `questions_${ex_id}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError("下载题目失败");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const handleDownloadA = async () => {
+    if (!exercise) return;
+    setDownloading(true);
+    try {
+      const blob = await downloadExerciseAnswersPdf(ex_id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `answers_${ex_id}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError("下载答案失败");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const handleAssign = async () => {
+    setAssigning(true);
+    try {
+      await assignExercise(ex_id);
+      setAssigned(true);
+    } catch (err) {
+      setError("布置作业失败");
+    } finally {
+      setAssigning(false);
+    }
+  };
+
+  const handleStats = () => {
+    navigate(`/teacher/exercise/stats/${ex_id}`);
+  };
+
+  const renderQuestion = (block, idx) => (
+    <div key={idx} style={{ marginBottom: "1rem" }}>
+      <strong>{idx + 1}. [{block.type}]</strong>
+      {block.items && (
+        <div>
+          {block.items.map((item) => (
+            <div key={item.id} style={{ marginTop: "0.5rem" }}>
+              <div>{item.question}</div>
+              {item.options && (
+                <ul>
+                  {item.options.map((opt, i) => (
+                    <li key={i}>{opt}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h2>练习预览</h2>
+        {error && <div className="error">{error}</div>}
+        {loading || !exercise ? (
+          <div>加载中...</div>
+        ) : (
+          <>
+            <div style={{ margin: "1rem 0", display: "flex", gap: "0.5rem" }}>
+              <button className="button" onClick={handleDownloadQ} disabled={downloading}>
+                {downloading ? "下载中..." : "下载题目"}
+              </button>
+              <button className="button" onClick={handleDownloadA} disabled={downloading}>
+                {downloading ? "下载中..." : "下载答案"}
+              </button>
+              <button className="button" onClick={handleAssign} disabled={assigned || assigning}>
+                {assigned ? "已布置" : assigning ? "布置中..." : "布置作业"}
+              </button>
+              <button className="button" onClick={handleStats}>统计</button>
+            </div>
+            <div>
+              {exercise.prompt.map((b, i) => renderQuestion(b, i))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ExerciseStats.jsx
+++ b/frontend/src/pages/ExerciseStats.jsx
@@ -1,0 +1,45 @@
+// src/pages/ExerciseStats.jsx
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { fetchExerciseStats } from "../api/teacher";
+import "../index.css";
+
+export default function ExerciseStats() {
+  const { ex_id } = useParams();
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await fetchExerciseStats(ex_id);
+        setStats(data);
+      } catch (err) {
+        setError("加载统计失败，请稍后重试");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [ex_id]);
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h2>练习统计</h2>
+        {error && <div className="error">{error}</div>}
+        {loading || !stats ? (
+          <div>加载中...</div>
+        ) : (
+          <ul>
+            <li>提交数量：{stats.total_submissions}</li>
+            <li>平均得分：{stats.average_score}</li>
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/TeacherPage.jsx
+++ b/frontend/src/pages/TeacherPage.jsx
@@ -14,6 +14,10 @@ export default function TeacherPage() {
     navigate("/teacher/lesson/list");  // 跳转到课程列表页面
   };
 
+  const handleExerciseList = () => {
+    navigate("/teacher/exercise/list");
+  };
+
   return (
     <div className="container">
       <div className="card">
@@ -24,6 +28,9 @@ export default function TeacherPage() {
           </button>
           <button className="button" onClick={handleLessonList}>
             课程列表
+          </button>
+          <button className="button" onClick={handleExerciseList}>
+            练习列表
           </button>
         </div>
       </div>

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -6,6 +6,9 @@ import TeacherPage from "../pages/TeacherPage";
 import TeacherLesson from "../pages/TeacherLesson";
 import LessonList from "../pages/LessonList"; 
 import LessonPreview from "../pages/LessonPreview";
+import ExerciseList from "../pages/ExerciseList";
+import ExercisePreview from "../pages/ExercisePreview";
+import ExerciseStats from "../pages/ExerciseStats";
 import RegisterPage from "../pages/RegisterPage";
 import StudentHomeworks from "../pages/StudentHomeworks";
 import AdminPage from "../pages/AdminPage";
@@ -36,7 +39,11 @@ export default function AppRouter() {
               <Route path="/" element={<TeacherPage />} />
               <Route path="lesson" element={<TeacherLesson />} />
               <Route path="lesson/list" element={<LessonList />} />
-              <Route path="lesson/preview/:cw_id" element={<LessonPreview />} />  
+
+              <Route path="lesson/preview/:cw_id" element={<LessonPreview />} />
+              <Route path="exercise/list" element={<ExerciseList />} />
+              <Route path="exercise/preview/:ex_id" element={<ExercisePreview />} />
+              <Route path="exercise/stats/:ex_id" element={<ExerciseStats />} />
               <Route path="*" element={<Navigate to="lesson" replace />} />
             </Routes>
           </ProtectedRoute>


### PR DESCRIPTION
## Summary
- implement API helpers for exercise management
- show teacher's exercise list
- preview exercises with download and assign options
- display exercise stats
- wire new pages into router and teacher dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68511c5bff0083229daac3ca14e21ad9