### PR TITLE
Fix homework loading issue

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -16,4 +16,16 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
+// 全局响应拦截：未授权时跳转登录
+instance.interceptors.response.use(
+  (resp) => resp,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem("token");
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default instance;

--- a/frontend/src/pages/StudentHomeworkResult.jsx
+++ b/frontend/src/pages/StudentHomeworkResult.jsx
@@ -16,7 +16,8 @@ export default function StudentHomeworkResult() {
         setData(resp.data);
       } catch (err) {
         console.error(err);
-        setError("加载失败");
+        const detail = err.response?.data?.detail;
+        setError(detail ? `加载失败：${detail}` : "加载失败");
       }
     };
     load();

--- a/frontend/src/pages/StudentHomeworks.jsx
+++ b/frontend/src/pages/StudentHomeworks.jsx
@@ -9,8 +9,12 @@ export default function StudentHomeworks() {
 
   useEffect(() => {
     const load = async () => {
-      const resp = await api.get("/student/homeworks");
-      setList(resp.data);
+      try {
+        const resp = await api.get("/student/homeworks");
+        setList(resp.data);
+      } catch (err) {
+        console.error(err);
+      }
     };
     load();
   }, []);


### PR DESCRIPTION
## Summary
- add global response interceptor to redirect on 401 errors
- show server error details when loading homework results
- handle errors when fetching homework list

## Testing
- `npm run lint`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68515680bcfc8322be8de25ab332f406