### PR TITLE
Implement chat sessions for student AI teacher

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -103,6 +103,30 @@ class ChatHistory(SQLModel, table=True):
     student: "User" = Relationship(back_populates="chats")
 
 
+class ChatSession(SQLModel, table=True):
+    __tablename__ = "chat_session"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    student_id: int = Field(foreign_key="user.id", nullable=False)
+    title: str = Field(max_length=255, default="New Chat")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    student: "User" = Relationship()
+    messages: List["ChatMessage"] = Relationship(back_populates="session")
+
+
+class ChatMessage(SQLModel, table=True):
+    __tablename__ = "chat_message"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    session_id: int = Field(foreign_key="chat_session.id", nullable=False)
+    role: str = Field(max_length=20)
+    content: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    session: ChatSession = Relationship(back_populates="messages")
+
+
 class Practice(SQLModel, table=True):
     __tablename__ = "practice"
 

--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -3,9 +3,22 @@ from fastapi import APIRouter, Depends, HTTPException
 from backend.auth import get_current_user
 from backend.models import User
 from backend.schemas.student_schema import (
-    AskRequest, ChatOut, PracticeGenerateRequest, PracticeOut, PracticeSubmitRequest
+    AskRequest,
+    ChatOut,
+    SessionOut,
+    MessageOut,
+    PracticeGenerateRequest,
+    PracticeOut,
+    PracticeSubmitRequest,
 )
-from backend.services.chat_service import ask_question, list_history
+from backend.services.chat_service import (
+    ask_question,
+    list_history,
+    create_session,
+    list_sessions,
+    get_messages,
+    ask_in_session,
+)
 from backend.services.practice_service import (
     generate_practice, list_practices, get_practice, submit_practice
 )
@@ -21,6 +34,30 @@ def api_ask(req: AskRequest, user: User = Depends(get_current_user)):
 def api_history(user: User = Depends(get_current_user)):
     chats = list_history(user.id)
     return [ChatOut(id=c.id, question=c.question, answer=c.answer, created_at=c.created_at) for c in chats]
+
+
+@router.post("/session", response_model=SessionOut)
+def api_create_session(user: User = Depends(get_current_user)):
+    session = create_session(user.id)
+    return SessionOut(id=session.id, title=session.title, created_at=session.created_at)
+
+
+@router.get("/sessions", response_model=List[SessionOut])
+def api_list_sessions(user: User = Depends(get_current_user)):
+    sessions = list_sessions(user.id)
+    return [SessionOut(id=s.id, title=s.title, created_at=s.created_at) for s in sessions]
+
+
+@router.get("/session/{sid}", response_model=List[MessageOut])
+def api_get_messages(sid: int, user: User = Depends(get_current_user)):
+    msgs = get_messages(user.id, sid)
+    return [MessageOut(id=m.id, session_id=m.session_id, role=m.role, content=m.content, created_at=m.created_at) for m in msgs]
+
+
+@router.post("/session/{sid}/ask", response_model=MessageOut)
+def api_ask_in_session(sid: int, req: AskRequest, user: User = Depends(get_current_user)):
+    msg = ask_in_session(user.id, sid, req.question)
+    return MessageOut(id=msg.id, session_id=msg.session_id, role=msg.role, content=msg.content, created_at=msg.created_at)
 
 router_practice = APIRouter(prefix="/student/practice", tags=["student-practice"])
 

--- a/backend/schemas/student_schema.py
+++ b/backend/schemas/student_schema.py
@@ -14,6 +14,26 @@ class ChatOut(BaseModel):
     class Config:
         from_attributes = True
 
+
+class SessionOut(BaseModel):
+    id: int
+    title: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class MessageOut(BaseModel):
+    id: int
+    session_id: int
+    role: str
+    content: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
 class PracticeGenerateRequest(BaseModel):
     requirement: str
 

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,8 +1,9 @@
 from typing import List
 from sqlmodel import Session, select
 from backend.config import engine
-from backend.models import ChatHistory
-from backend.utils.deepseek_client import call_deepseek_api
+from backend.models import ChatHistory, ChatSession, ChatMessage
+from backend.utils.deepseek_client import call_deepseek_api, call_deepseek_api_chat
+from datetime import datetime
 
 def ask_question(student_id: int, question: str) -> ChatHistory:
     resp = call_deepseek_api(question)
@@ -18,3 +19,46 @@ def list_history(student_id: int) -> List[ChatHistory]:
     with Session(engine) as sess:
         stmt = select(ChatHistory).where(ChatHistory.student_id == student_id).order_by(ChatHistory.created_at.desc())
         return sess.exec(stmt).all()
+
+
+def create_session(student_id: int) -> ChatSession:
+    with Session(engine) as sess:
+        session = ChatSession(student_id=student_id, title=f"Chat {datetime.utcnow().strftime('%Y-%m-%d %H:%M')}")
+        sess.add(session)
+        sess.commit()
+        sess.refresh(session)
+        return session
+
+
+def list_sessions(student_id: int) -> List[ChatSession]:
+    with Session(engine) as sess:
+        stmt = select(ChatSession).where(ChatSession.student_id == student_id).order_by(ChatSession.created_at.desc())
+        return sess.exec(stmt).all()
+
+
+def get_messages(student_id: int, session_id: int) -> List[ChatMessage]:
+    with Session(engine) as sess:
+        session = sess.get(ChatSession, session_id)
+        if not session or session.student_id != student_id:
+            return []
+        stmt = select(ChatMessage).where(ChatMessage.session_id == session_id).order_by(ChatMessage.created_at)
+        return sess.exec(stmt).all()
+
+
+def ask_in_session(student_id: int, session_id: int, question: str) -> ChatMessage:
+    with Session(engine) as sess:
+        session = sess.get(ChatSession, session_id)
+        if not session or session.student_id != student_id:
+            raise ValueError("session not found")
+        user_msg = ChatMessage(session_id=session_id, role="user", content=question)
+        sess.add(user_msg)
+        sess.commit()
+        msgs = sess.exec(select(ChatMessage).where(ChatMessage.session_id == session_id).order_by(ChatMessage.created_at)).all()
+        conv = [{"role": m.role, "content": m.content} for m in msgs]
+        resp = call_deepseek_api_chat(conv)
+        answer = resp["choices"][0]["message"]["content"]
+        ai_msg = ChatMessage(session_id=session_id, role="assistant", content=answer)
+        sess.add(ai_msg)
+        sess.commit()
+        sess.refresh(ai_msg)
+        return ai_msg

--- a/backend/utils/deepseek_client.py
+++ b/backend/utils/deepseek_client.py
@@ -32,3 +32,28 @@ def call_deepseek_api(prompt: str, model: str = "deepseek-chat", temperature: fl
         return resp.json()
     else:
         raise Exception(f"API 请求失败，状态码: {resp.status_code}, 错误信息: {resp.text}")
+
+
+def call_deepseek_api_chat(messages, model: str = "deepseek-chat", temperature: float = 0.7, max_tokens: int = 4096):
+    """调用 Deepseek 聊天接口（多轮对话）"""
+    url = settings.DEEPSEEK_ENDPOINT
+    headers = {
+        "Authorization": f"Bearer {settings.DEEPSEEK_API_KEY}",
+        "Content-Type": "application/json"
+    }
+    data = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens
+    }
+    print(">>> Deepseek 请求 URL：", url)
+    print(">>> Deepseek 请求头：", headers)
+    print(">>> Deepseek 请求体：", data)
+    resp = requests.post(url, headers=headers, json=data, timeout=100, allow_redirects=False)
+    print(">>> Deepseek 返回状态码：", resp.status_code)
+    print(">>> Deepseek 返回体：", resp.text)
+    if resp.status_code == 200:
+        return resp.json()
+    else:
+        raise Exception(f"API 请求失败，状态码: {resp.status_code}, 错误信息: {resp.text}")

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -1,28 +1,80 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import api from "../api/api";
-import { Link } from "react-router-dom";
+import { Link, useParams, useNavigate } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import "../index.css";
 
 export default function StudentAiTeacher() {
-  const [question, setQuestion] = useState("");
+  const { sessionId } = useParams();
+  const navigate = useNavigate();
+  const [sessions, setSessions] = useState([]);
+  const [current, setCurrent] = useState(null);
   const [messages, setMessages] = useState([]);
+  const [question, setQuestion] = useState("");
+
+  useEffect(() => {
+    const loadSessions = async () => {
+      const resp = await api.get("/student/ai/sessions");
+      setSessions(resp.data);
+      let sid = sessionId ? parseInt(sessionId) : null;
+      if (!sid) {
+        if (resp.data.length > 0) sid = resp.data[0].id;
+        else {
+          const r = await api.post("/student/ai/session");
+          sid = r.data.id;
+        }
+      }
+      setCurrent(sid);
+      navigate(`/student/ai/${sid}`, { replace: true });
+    };
+    loadSessions();
+  }, [sessionId, navigate]);
+
+  useEffect(() => {
+    if (!current) return;
+    const loadMsgs = async () => {
+      const resp = await api.get(`/student/ai/session/${current}`);
+      setMessages(resp.data);
+    };
+    loadMsgs();
+  }, [current]);
 
   const send = async () => {
-    if (!question) return;
-    const resp = await api.post("/student/ai/ask", { question });
-    setMessages((prev) => [...prev, { q: question, a: resp.data.answer }]);
+    if (!question || !current) return;
+    const resp = await api.post(`/student/ai/session/${current}/ask`, { question });
+    setMessages((prev) => [...prev, { role: "user", content: question }, resp.data]);
     setQuestion("");
+  };
+
+  const newChat = async () => {
+    const resp = await api.post("/student/ai/session");
+    setSessions((prev) => [resp.data, ...prev]);
+    setCurrent(resp.data.id);
+    setMessages([]);
+    navigate(`/student/ai/${resp.data.id}`);
   };
 
   return (
     <div className="container">
       <div className="card">
         <h2>AI 教师</h2>
-        <div>
+        <div className="actions" style={{ justifyContent: "space-between" }}>
+          <button className="button" onClick={newChat}>新建聊天</button>
+          <select value={current || ""} onChange={(e) => navigate(`/student/ai/${e.target.value}`)}>
+            {sessions.map((s) => (
+              <option key={s.id} value={s.id}>{s.title}</option>
+            ))}
+          </select>
+          <Link className="button" to="history">历史记录</Link>
+        </div>
+        <div style={{ marginTop: "1rem", minHeight: "300px" }}>
           {messages.map((m, idx) => (
             <div key={idx} style={{ marginBottom: "1rem" }}>
-              <div>Q: {m.q}</div>
-              <div>A: {m.a}</div>
+              <strong>{m.role === "user" ? "我" : "AI"}:</strong>
+              <div className="markdown-preview">
+                <ReactMarkdown children={m.content} remarkPlugins={[remarkGfm]} />
+              </div>
             </div>
           ))}
         </div>
@@ -30,10 +82,10 @@ export default function StudentAiTeacher() {
           className="input"
           value={question}
           onChange={(e) => setQuestion(e.target.value)}
+          placeholder="请输入问题"
         />
         <div className="actions">
           <button className="button" onClick={send}>发送</button>
-          <Link className="button" to="history">历史记录</Link>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/StudentChatHistory.jsx
+++ b/frontend/src/pages/StudentChatHistory.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import api from "../api/api";
+import { Link } from "react-router-dom";
 import "../index.css";
 
 export default function StudentChatHistory() {
@@ -7,7 +8,7 @@ export default function StudentChatHistory() {
 
   useEffect(() => {
     const load = async () => {
-      const resp = await api.get("/student/ai/history");
+      const resp = await api.get("/student/ai/sessions");
       setHistory(resp.data);
     };
     load();
@@ -20,7 +21,7 @@ export default function StudentChatHistory() {
         <ul>
           {history.map((item) => (
             <li key={item.id}>
-              Q: {item.question} <br />A: {item.answer}
+              <Link to={`/student/ai/${item.id}`}>{item.title}</Link>
             </li>
           ))}
         </ul>

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -68,6 +68,7 @@ export default function AppRouter() {
               <Route path="homeworks" element={<StudentHomeworks />} />
               <Route path="homeworks/result/:hw_id" element={<StudentHomeworkResult />} />
               <Route path="ai" element={<StudentAiTeacher />} />
+              <Route path="ai/:sessionId" element={<StudentAiTeacher />} />
               <Route path="ai/history" element={<StudentChatHistory />} />
               <Route path="evaluate" element={<EvaluateAssistant />} />
               <Route path="practice" element={<StudentPracticeList />} />


### PR DESCRIPTION
## Summary
- add `ChatSession` and `ChatMessage` models
- create service utilities for chat sessions
- expose chat session APIs in `student_router`
- extend Deepseek client for conversation mode
- update React pages for new session-based chat
- link sessions from chat history

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68515b8ac5e483229b1e95517515cd23