### PR TITLE
Update student evaluation flow

### DIFF
--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -70,7 +70,7 @@ def api_delete_session(sid: int, user: User = Depends(get_current_user)):
 
 
 
-router_practice = APIRouter(prefix="/student/practice", tags=["student-practice"])
+router_practice = APIRouter(prefix="/student/self_practice", tags=["student-self_practice"])
 
 @router_practice.post("/generate", response_model=PracticeOut)
 def api_generate(req: PracticeGenerateRequest, user: User = Depends(get_current_user)):
@@ -95,14 +95,14 @@ def api_list(user: User = Depends(get_current_user)):
 def api_submit(pid: int, req: PracticeSubmitRequest, user: User = Depends(get_current_user)):
     pr = submit_practice(pid, user.id, req.answers)
     if not pr:
-        raise HTTPException(404, "practice not found")
+        raise HTTPException(404, "self practice not found")
     return PracticeOut(id=pr.id, topic=pr.topic, questions=pr.questions, answers=pr.answers, status=pr.status, feedback=pr.feedback, score=pr.score)
 
 
-from backend.services.analysis_service import analyze_student_practice
+from backend.services.analysis_service import analyze_student_homeworks
 
 router_analysis = APIRouter(prefix="/student", tags=["student-analysis"])
 
 @router_analysis.get("/analysis")
 def api_analysis(user: User = Depends(get_current_user)):
-    return analyze_student_practice(user.id)
+    return analyze_student_homeworks(user.id)

--- a/frontend/src/api/student.js
+++ b/frontend/src/api/student.js
@@ -10,17 +10,17 @@ export async function fetchChatHistory() {
   return resp.data;
 }
 
-export async function generatePractice(requirement) {
-  const resp = await api.post("/student/practice/generate", { requirement });
+export async function generateSelfPractice(requirement) {
+  const resp = await api.post("/student/self_practice/generate", { requirement });
   return resp.data;
 }
 
-export async function fetchPracticeList() {
-  const resp = await api.get("/student/practice/list");
+export async function fetchSelfPracticeList() {
+  const resp = await api.get("/student/self_practice/list");
   return resp.data;
 }
 
-export async function submitPractice(id, answers) {
-  const resp = await api.post(`/student/practice/${id}/submit`, { answers });
+export async function submitSelfPractice(id, answers) {
+  const resp = await api.post(`/student/self_practice/${id}/submit`, { answers });
   return resp.data;
 }

--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -1,29 +1,36 @@
 import React, { useState, useEffect } from "react";
 import api from "../api/api";
 import { useNavigate } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import "../index.css";
 
 export default function EvaluateAssistant() {
   const [analysis, setAnalysis] = useState("");
+  const [analysisLoading, setAnalysisLoading] = useState(false);
   const [req, setReq] = useState("");
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
+      setAnalysis("");
+      setAnalysisLoading(true);
       try {
         const resp = await api.get("/student/analysis");
         setAnalysis(resp.data.analysis || JSON.stringify(resp.data));
       } catch (err) {
         console.error(err);
         setError("加载分析失败");
+      } finally {
+        setAnalysisLoading(false);
       }
     };
     load();
   }, []);
 
   const gen = async () => {
-    const resp = await api.post("/student/practice/generate", { requirement: req });
+    const resp = await api.post("/student/self_practice/generate", { requirement: req });
     alert("已生成并保存随练ID:" + resp.data.id);
   };
 
@@ -32,7 +39,11 @@ export default function EvaluateAssistant() {
       <div className="card">
         <h2>评测助手</h2>
         {error && <div className="error">{error}</div>}
-        <div style={{ whiteSpace: "pre-wrap", marginBottom: "1rem" }}>{analysis}</div>
+        <div className="markdown-preview" style={{ minHeight: '6rem', marginBottom: '1rem' }}>
+          {analysisLoading ? '正在努力为您分析学习情况…' : (
+            <ReactMarkdown children={analysis} remarkPlugins={[remarkGfm]} />
+          )}
+        </div>
         <input
           className="input"
           value={req}
@@ -41,7 +52,7 @@ export default function EvaluateAssistant() {
         />
         <div className="actions">
           <button className="button" onClick={gen}>生成随练</button>
-          <button className="button" onClick={() => navigate("/student/practice")}>我的随练</button>
+          <button className="button" onClick={() => navigate("/student/self_practice")}>我的随练</button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -3,14 +3,14 @@ import { useParams } from "react-router-dom";
 import api from "../api/api";
 import "../index.css";
 
-export default function StudentPracticeDetail() {
+export default function SelfPracticeDetail() {
   const { id } = useParams();
   const [practice, setPractice] = useState(null);
   const [answers, setAnswers] = useState({});
 
   useEffect(() => {
     const load = async () => {
-      const resp = await api.get(`/student/practice/list`);
+      const resp = await api.get(`/student/self_practice/list`);
       const item = resp.data.find((p) => String(p.id) === id);
       if (item) setPractice(item);
     };
@@ -18,7 +18,7 @@ export default function StudentPracticeDetail() {
   }, [id]);
 
   const submit = async () => {
-    await api.post(`/student/practice/${id}/submit`, { answers });
+    await api.post(`/student/self_practice/${id}/submit`, { answers });
     alert("已提交");
   };
 

--- a/frontend/src/pages/SelfPracticeList.jsx
+++ b/frontend/src/pages/SelfPracticeList.jsx
@@ -3,13 +3,13 @@ import { useNavigate } from "react-router-dom";
 import api from "../api/api";
 import "../index.css";
 
-export default function StudentPracticeList() {
+export default function SelfPracticeList() {
   const [list, setList] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
-      const resp = await api.get("/student/practice/list");
+      const resp = await api.get("/student/self_practice/list");
       setList(resp.data);
     };
     load();
@@ -35,7 +35,7 @@ export default function StudentPracticeList() {
                 <td>
                   <button
                     className="button"
-                    onClick={() => navigate(`/student/practice/${p.id}`)}
+                    onClick={() => navigate(`/student/self_practice/${p.id}`)}
                   >
                     查看
                   </button>

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -21,8 +21,8 @@ import StudentHomeworkAnswer from "../pages/StudentHomeworkAnswer";
 import StudentAiTeacher from "../pages/StudentAiTeacher";
 import StudentChatHistory from "../pages/StudentChatHistory";
 import EvaluateAssistant from "../pages/EvaluateAssistant";
-import StudentPracticeList from "../pages/StudentPracticeList";
-import StudentPracticeDetail from "../pages/StudentPracticeDetail";
+import SelfPracticeList from "../pages/SelfPracticeList";
+import SelfPracticeDetail from "../pages/SelfPracticeDetail";
 import AdminPage from "../pages/AdminPage";
 
 // 受保护路由：检查是否已登录且角色匹配
@@ -79,8 +79,8 @@ export default function AppRouter() {
               <Route path="ai/:sessionId" element={<StudentAiTeacher />} />
               <Route path="ai/history" element={<StudentChatHistory />} />
               <Route path="evaluate" element={<EvaluateAssistant />} />
-              <Route path="practice" element={<StudentPracticeList />} />
-              <Route path="practice/:id" element={<StudentPracticeDetail />} />
+              <Route path="self_practice" element={<SelfPracticeList />} />
+              <Route path="self_practice/:id" element={<SelfPracticeDetail />} />
               <Route path="*" element={<Navigate to="/student" replace />} />
             </Routes>
           </ProtectedRoute>


### PR DESCRIPTION
## Summary
- rename practice routes to self_practice to avoid confusion
- add markdown loading box for student evaluation page
- parse AI result via helper like teacher side for self practice generation
- analyze completed exercise homeworks for student analysis

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68539e65cc5c8322a8d4957d0f7bcb86