### PR TITLE
Fix self practice preview layout

### DIFF
--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -78,7 +78,14 @@ router_practice = APIRouter(prefix="/student/self_practice", tags=["student-self
 
 @router_practice.post("/generate", response_model=PracticeOut)
 def api_generate(req: PracticeGenerateRequest, user: User = Depends(get_current_user)):
-    pr = generate_practice(user.id, req.requirement)
+    pr = generate_practice(
+        user.id,
+        topic=req.topic,
+        num_mcq=req.num_mcq,
+        num_fill_blank=req.num_fill_blank,
+        num_short_answer=req.num_short_answer,
+        num_programming=req.num_programming,
+    )
     return PracticeOut(
         id=pr.id,
         topic=pr.topic,

--- a/backend/schemas/student_schema.py
+++ b/backend/schemas/student_schema.py
@@ -35,7 +35,11 @@ class MessageOut(BaseModel):
         from_attributes = True
 
 class PracticeGenerateRequest(BaseModel):
-    requirement: str
+    topic: str
+    num_mcq: int = 0
+    num_fill_blank: int = 0
+    num_short_answer: int = 0
+    num_programming: int = 0
 
 class PracticeSubmitRequest(BaseModel):
     answers: Dict[str, Any]

--- a/frontend/src/api/student.js
+++ b/frontend/src/api/student.js
@@ -10,8 +10,8 @@ export async function fetchChatHistory() {
   return resp.data;
 }
 
-export async function generateSelfPractice(requirement) {
-  const resp = await api.post("/student/self_practice/generate", { requirement });
+export async function generateSelfPractice(params) {
+  const resp = await api.post("/student/self_practice/generate", params);
   return resp.data;
 }
 

--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -9,7 +9,15 @@ import "../index.css";
 export default function EvaluateAssistant() {
   const [analysis, setAnalysis] = useState("");
   const [analysisLoading, setAnalysisLoading] = useState(false);
-  const [req, setReq] = useState("");
+  const [form, setForm] = useState({
+    topic: "",
+    num_mcq: 5,
+    num_fill_blank: 5,
+    num_short_answer: 1,
+    num_programming: 0,
+  });
+  const [preview, setPreview] = useState(null);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
@@ -30,9 +38,27 @@ export default function EvaluateAssistant() {
     load();
   }, []);
 
-  const gen = async () => {
-    const data = await generateSelfPractice(req);
-    alert("已生成并保存随练ID:" + data.id);
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: name.startsWith("num_") ? Number(value) : value,
+    }));
+  };
+
+  const gen = async (e) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const data = await generateSelfPractice(form);
+      setPreview(data);
+    } catch (err) {
+      console.error(err);
+      setError(err.response?.data?.detail || "生成失败");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -45,16 +71,91 @@ export default function EvaluateAssistant() {
             <ReactMarkdown children={analysis} remarkPlugins={[remarkGfm]} />
           )}
         </div>
-        <input
-          className="input"
-          value={req}
-          onChange={(e) => setReq(e.target.value)}
-          placeholder="练习要求"
-        />
-        <div className="actions">
-          <button className="button" onClick={gen}>生成随练</button>
-          <button className="button" onClick={() => navigate("/student/self_practice")}>我的随练</button>
-        </div>
+        <form onSubmit={gen}>
+          <label>
+            主题
+            <input
+              className="input"
+              name="topic"
+              value={form.topic}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            选择题数量
+            <input
+              className="input"
+              type="number"
+              name="num_mcq"
+              value={form.num_mcq}
+              onChange={handleChange}
+              min="0"
+            />
+          </label>
+          <label>
+            填空题数量
+            <input
+              className="input"
+              type="number"
+              name="num_fill_blank"
+              value={form.num_fill_blank}
+              onChange={handleChange}
+              min="0"
+            />
+          </label>
+          <label>
+            简答题数量
+            <input
+              className="input"
+              type="number"
+              name="num_short_answer"
+              value={form.num_short_answer}
+              onChange={handleChange}
+              min="0"
+            />
+          </label>
+          <label>
+            编程题数量
+            <input
+              className="input"
+              type="number"
+              name="num_programming"
+              value={form.num_programming}
+              onChange={handleChange}
+              min="0"
+            />
+          </label>
+          <button className="button" type="submit" disabled={loading}>
+            {loading ? "生成中…" : "生成随练"}
+          </button>
+        </form>
+        {preview && (
+          <>
+            <div className="actions">
+              <button className="button" onClick={() => navigate("/student/self_practice")}>我的随练</button>
+            </div>
+            <div style={{ marginTop: "1rem" }}>
+              {preview.questions.map((block, bIdx) => (
+                <div key={bIdx} style={{ marginBottom: "1rem" }}>
+                  <strong>{block.type}</strong>
+                  {block.items.map((item, i) => (
+                    <div key={i} style={{ marginLeft: "1rem" }}>
+                      {item.question}
+                      {item.options && (
+                        <ul>
+                          {item.options.map((opt, j) => (
+                            <li key={j}>{opt}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -67,7 +67,7 @@ export default function SelfPracticeDetail() {
                             ))}
                           </ul>
                         )}
-                        <div>答案：{practice.answers[item.id]}</div>
+                        <div>答案：{practice.answers[String(item.id)]}</div>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -54,10 +54,10 @@ export default function SelfPracticeDetail() {
                 </button>
               </div>
               <div style={{ marginTop: "1rem" }}>
-                {practice.questions.map((block, bIdx) => (
+                {(practice.questions || []).map((block, bIdx) => (
                   <div key={bIdx} style={{ marginBottom: "1rem" }}>
                     <strong>{block.type}</strong>
-                    {block.items.map((item, i) => (
+                    {(block.items || []).map((item, i) => (
                       <div key={i} style={{ marginLeft: "1rem" }}>
                         {item.question}
                         {item.options && (
@@ -67,7 +67,11 @@ export default function SelfPracticeDetail() {
                             ))}
                           </ul>
                         )}
-                        <div>答案：{practice.answers[String(item.id)]}</div>
+                        <div>
+                          答案：
+                          {practice.answers[item.id] ??
+                            practice.answers[String(item.id)]}
+                        </div>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/pages/SelfPracticeList.jsx
+++ b/frontend/src/pages/SelfPracticeList.jsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { fetchSelfPracticeList } from "../api/student";
 import "../index.css";
 
 export default function SelfPracticeList() {
   const [list, setList] = useState([]);
-  const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
@@ -31,12 +30,9 @@ export default function SelfPracticeList() {
               <tr key={p.id}>
                 <td>{p.topic}</td>
                 <td>
-                  <button
-                    className="button"
-                    onClick={() => navigate(`/student/self_practice/${p.id}`)}
-                  >
+                  <Link className="button" to={`/student/self_practice/${p.id}`}>
                     查看
-                  </button>
+                  </Link>
                 </td>
               </tr>
             ))}

--- a/frontend/src/pages/SelfPracticeList.jsx
+++ b/frontend/src/pages/SelfPracticeList.jsx
@@ -33,7 +33,7 @@ export default function SelfPracticeList() {
                 <td>
                   <button
                     className="button"
-                    onClick={() => navigate(`self_practice/${p.id}`)}
+                    onClick={() => navigate(`/student/self_practice/${p.id}`)}
                   >
                     查看
                   </button>

--- a/frontend/src/pages/SelfPracticeList.jsx
+++ b/frontend/src/pages/SelfPracticeList.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { fetchSelfPracticeList, downloadSelfPracticePdf } from "../api/student";
+import { fetchSelfPracticeList } from "../api/student";
 import "../index.css";
 
 export default function SelfPracticeList() {
@@ -33,26 +33,9 @@ export default function SelfPracticeList() {
                 <td>
                   <button
                     className="button"
-                    onClick={() => navigate(`/student/self_practice/${p.id}`)}
+                    onClick={() => navigate(`self_practice/${p.id}`)}
                   >
                     查看
-                  </button>
-                  <button
-                    className="button"
-                    style={{ marginLeft: "0.5rem" }}
-                    onClick={async () => {
-                      const blob = await downloadSelfPracticePdf(p.id);
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement("a");
-                      a.href = url;
-                      a.download = `self_practice_${p.id}.pdf`;
-                      document.body.appendChild(a);
-                      a.click();
-                      a.remove();
-                      URL.revokeObjectURL(url);
-                    }}
-                  >
-                    下载 PDF
                   </button>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- use teacher exercise preview style for self practice detail
- show one download button for answers

## Testing
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a5715e4483229ddc4988d8b71e23