### PR TITLE
Add navigation buttons across pages

### DIFF
--- a/frontend/src/components/NavButtons.jsx
+++ b/frontend/src/components/NavButtons.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+
+export default function NavButtons() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const role = localStorage.getItem("role");
+
+  let home = "/";
+  if (role === "teacher") home = "/teacher";
+  else if (role === "student") home = "/student";
+  else if (role === "admin") home = "/admin";
+
+  const rootPaths = ["/", "/login", "/register", "/teacher", "/student", "/admin"];
+
+  if (rootPaths.includes(location.pathname)) {
+    return null;
+  }
+
+  return (
+    <div className="actions" style={{ marginBottom: "1rem" }}>
+      <button className="button" style={{ width: "auto" }} onClick={() => navigate(home)}>
+        首页
+      </button>
+      <button className="button" style={{ width: "auto" }} onClick={() => navigate(-1)}>
+        返回
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import api from "../api/api";
 import { generateSelfPractice } from "../api/student";
 import { useNavigate } from "react-router-dom";
+import NavButtons from "../components/NavButtons";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import "../index.css";
@@ -65,6 +66,7 @@ export default function EvaluateAssistant() {
     <div className="container">
       <div className="card">
         <h2>评测助手</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         <div className="markdown-preview" style={{ minHeight: '6rem', marginBottom: '1rem' }}>
           {analysisLoading ? '正在努力为您分析学习情况…' : (

--- a/frontend/src/pages/ExerciseList.jsx
+++ b/frontend/src/pages/ExerciseList.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { fetchExerciseList } from "../api/teacher";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function ExerciseList() {
   const [list, setList] = useState([]);
@@ -29,6 +30,7 @@ export default function ExerciseList() {
     <div className="container">
       <div className="card">
         <h2>我的练习列表</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>

--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -7,6 +7,7 @@ import {
   downloadAnswersPdf,
 } from "../api/teacher";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function ExercisePage() {
   const [form, setForm] = useState({
@@ -122,6 +123,7 @@ export default function ExercisePage() {
     <div className="container">
       <div className="card">
         <h2>练习题生成</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         <form onSubmit={handleGenerate}>
           <label>

--- a/frontend/src/pages/ExercisePreview.jsx
+++ b/frontend/src/pages/ExercisePreview.jsx
@@ -7,6 +7,7 @@ import {
   assignExercise,
 } from "../api/teacher";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function ExercisePreview() {
   const { ex_id } = useParams();
@@ -85,6 +86,7 @@ export default function ExercisePreview() {
     <div className="container">
       <div className="card">
         <h2>练习预览</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>

--- a/frontend/src/pages/ExerciseStats.jsx
+++ b/frontend/src/pages/ExerciseStats.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { fetchExerciseStats } from "../api/teacher";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function ExerciseStats() {
   const { ex_id } = useParams();
@@ -30,6 +31,7 @@ export default function ExerciseStats() {
     <div className="container">
       <div className="card">
         <h2>练习统计</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>

--- a/frontend/src/pages/LessonList.jsx
+++ b/frontend/src/pages/LessonList.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { fetchLessonList } from "../api/teacher";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function LessonList() {
   const [lessons, setLessons] = useState([]);
@@ -30,6 +31,7 @@ export default function LessonList() {
     <div className="container">
       <div className="card">
         <h2>我的教案列表</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}  {/* 错误显示 */}
         {loading ? (
           <div>加载中...</div>

--- a/frontend/src/pages/LessonPreview.jsx
+++ b/frontend/src/pages/LessonPreview.jsx
@@ -6,6 +6,7 @@ import { fetchLessonPreview, downloadCoursewarePdf } from "../api/teacher";  // 
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";  // 用于支持 GitHub 风格的 Markdown（包括表格）
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function LessonPreview() {
   const { cw_id } = useParams();  // 获取课件 ID
@@ -54,6 +55,7 @@ export default function LessonPreview() {
     <div className="container">
       <div className="card">
         <h2>教案预览</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}  {/* 错误显示 */}
         {loading ? (
           <div>加载中...</div>

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getSelfPractice, downloadSelfPracticePdf } from "../api/student";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function SelfPracticeDetail() {
   const { id } = useParams();
@@ -42,6 +43,7 @@ export default function SelfPracticeDetail() {
     <div className="container">
       <div className="card">
         <h2>随练预览</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>

--- a/frontend/src/pages/SelfPracticeList.jsx
+++ b/frontend/src/pages/SelfPracticeList.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { fetchSelfPracticeList } from "../api/student";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function SelfPracticeList() {
   const [list, setList] = useState([]);
@@ -18,6 +19,7 @@ export default function SelfPracticeList() {
     <div className="container">
       <div className="card">
         <h2>我的随练</h2>
+        <NavButtons />
         <table>
           <thead>
             <tr>

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -4,6 +4,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function StudentAiTeacher() {
   const { sessionId } = useParams();
@@ -109,6 +110,7 @@ export default function StudentAiTeacher() {
         </div>
         <div style={{ flex: 1 }}>
           <h2>AI 教师</h2>
+          <NavButtons />
           <div style={{ marginTop: "1rem", minHeight: "300px" }}>
             {messages.map((m, idx) => (
               <div

--- a/frontend/src/pages/StudentChatHistory.jsx
+++ b/frontend/src/pages/StudentChatHistory.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import api from "../api/api";
 import { Link } from "react-router-dom";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function StudentChatHistory() {
   const [history, setHistory] = useState([]);
@@ -27,6 +28,7 @@ export default function StudentChatHistory() {
     <div className="container">
       <div className="card">
         <h2>历史记录</h2>
+        <NavButtons />
         <ul>
           {history.map((item) => (
             <li key={item.id}>

--- a/frontend/src/pages/StudentHomeworkAnswer.jsx
+++ b/frontend/src/pages/StudentHomeworkAnswer.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import api from "../api/api";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function StudentHomeworkAnswer() {
   const { hw_id } = useParams();
@@ -92,6 +93,7 @@ export default function StudentHomeworkAnswer() {
     <div className="container">
       <div className="card">
         <h2>{exercise.subject}</h2>
+        <NavButtons />
         <div className="actions" style={{ flexWrap: "wrap" }}>
           {flat.map((q, idx) => (
             <button

--- a/frontend/src/pages/StudentHomeworkResult.jsx
+++ b/frontend/src/pages/StudentHomeworkResult.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import api from "../api/api";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function StudentHomeworkResult() {
   const { hw_id } = useParams();
@@ -43,6 +44,7 @@ export default function StudentHomeworkResult() {
     <div className="container">
       <div className="card">
         <h2>作业结果</h2>
+        <NavButtons />
         <div>总分：{score}</div>
         <div className="actions">
           {questions.map((q) => (

--- a/frontend/src/pages/StudentHomeworks.jsx
+++ b/frontend/src/pages/StudentHomeworks.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/api";
 import "../index.css";
+import NavButtons from "../components/NavButtons";
 
 export default function StudentHomeworks() {
   const navigate = useNavigate();
@@ -23,6 +24,7 @@ export default function StudentHomeworks() {
     <div className="container">
       <div className="card">
         <h2>我的作业</h2>
+        <NavButtons />
         <table>
           <thead>
             <tr>

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -3,6 +3,7 @@ import { prepareLessonMarkdown, downloadCoursewarePdf, saveCourseware } from "..
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";  // 引入 GitHub 风格的 Markdown 支持
 import "../index.css";  // 引用全局样式
+import NavButtons from "../components/NavButtons";
 
 export default function TeacherLesson() {
   const [topic, setTopic] = useState("");
@@ -66,6 +67,7 @@ export default function TeacherLesson() {
     <div className="container">
       <div className="card">
         <h2>教案备课</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         {saved && <div className="success">教案已保存！</div>}
         <form onSubmit={handleGenerate}>

--- a/frontend/src/pages/TeacherStudentDetail.jsx
+++ b/frontend/src/pages/TeacherStudentDetail.jsx
@@ -4,6 +4,7 @@ import { fetchStudentAnalysis, fetchStudentHomeworks } from '../api/teacher';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import '../index.css';
+import NavButtons from '../components/NavButtons';
 
 export default function TeacherStudentDetail() {
   const { sid } = useParams();
@@ -39,6 +40,7 @@ export default function TeacherStudentDetail() {
     <div className="container">
       <div className="card">
         <h2>学生 {sid} 学情</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         <div className="markdown-preview" style={{ minHeight: '6rem' }}>
           {analysisLoading ? '加载中...' : (

--- a/frontend/src/pages/TeacherStudentHomeworkDetail.jsx
+++ b/frontend/src/pages/TeacherStudentHomeworkDetail.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { fetchStudentHomeworkDetail } from '../api/teacher';
 import '../index.css';
+import NavButtons from '../components/NavButtons';
 
 export default function TeacherStudentHomeworkDetail() {
   const { sid, hw_id } = useParams();
@@ -37,6 +38,7 @@ export default function TeacherStudentHomeworkDetail() {
     <div className="container">
       <div className="card">
         <h2>作业 {hw_id} 详情</h2>
+        <NavButtons />
         <div>总分：{score}</div>
         <div className="actions">
           {questions.map((q) => (

--- a/frontend/src/pages/TeacherStudents.jsx
+++ b/frontend/src/pages/TeacherStudents.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchStudentList } from '../api/teacher';
 import '../index.css';
+import NavButtons from '../components/NavButtons';
 
 export default function TeacherStudents() {
   const [list, setList] = useState([]);
@@ -30,6 +31,7 @@ export default function TeacherStudents() {
     <div className="container">
       <div className="card">
         <h2>学生列表</h2>
+        <NavButtons />
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>


### PR DESCRIPTION
## Summary
- create `NavButtons` component
- add Home/Back navigation to most pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aae68aacc832287a29658f5e94d7f