### PR TITLE
Enhance frontend styles with animations

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,7 +4,8 @@ html, body, #root {
   height: 100%;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  background-color: #f5f5f7;
+  background-color: #f0f4f8;
+  animation: fade-in 0.5s ease-in-out;
 }
 
 .container {
@@ -22,6 +23,8 @@ html, body, #root {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 960px;  /* Set max width for larger screens */
+  animation: slide-up 0.6s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .card h2 {
@@ -48,10 +51,11 @@ html, body, #root {
   font-size: 1rem;
   border: none;
   border-radius: 8px;
-  background-color: #0071e3;
+  background: linear-gradient(90deg, #5b9df9, #2d74da);
   color: #fff;
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin-top: 1rem;
 }
 
@@ -61,7 +65,8 @@ html, body, #root {
 }
 
 .button:not(:disabled):hover {
-  background-color: #005bb5;
+  transform: scale(1.03);
+  filter: brightness(1.1);
 }
 
 .actions {
@@ -89,6 +94,20 @@ html, body, #root {
 
 .success {
   color: #28a745;
+}
+
+.link {
+  display: block;
+  margin-top: 1rem;
+  color: #2d74da;
+  text-align: center;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.link:hover {
+  color: #1b54a0;
+  text-decoration: underline;
 }
 
 
@@ -126,4 +145,20 @@ td {
 
 .icon-button:hover {
   background: #f0f0f0;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- update global page background and add fade-in animation
- animate card components on load with slide-up
- improve button gradient and hover effects
- style page links

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6860d860e3948322b8faff21d4a5d8b1