### PR TITLE
Add logout & back navigation

### DIFF
--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -64,6 +64,13 @@ export default function EvaluateAssistant() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>评测助手</h2>
         {error && <div className="error">{error}</div>}
         <div className="markdown-preview" style={{ minHeight: '6rem', marginBottom: '1rem' }}>

--- a/frontend/src/pages/ExerciseList.jsx
+++ b/frontend/src/pages/ExerciseList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { fetchExerciseList } from "../api/teacher";
 import "../index.css";
 
@@ -7,6 +7,7 @@ export default function ExerciseList() {
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
@@ -28,6 +29,13 @@ export default function ExerciseList() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>我的练习列表</h2>
         {error && <div className="error">{error}</div>}
         {loading ? (

--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   generateExerciseJson,
   saveExercise,
@@ -22,6 +23,7 @@ export default function ExercisePage() {
   const [error, setError] = useState("");
   const [saved, setSaved] = useState(false);
   const [assigned, setAssigned] = useState(false);
+  const navigate = useNavigate();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -121,6 +123,13 @@ export default function ExercisePage() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>练习题生成</h2>
         {error && <div className="error">{error}</div>}
         <form onSubmit={handleGenerate}>

--- a/frontend/src/pages/ExercisePreview.jsx
+++ b/frontend/src/pages/ExercisePreview.jsx
@@ -84,6 +84,13 @@ export default function ExercisePreview() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>练习预览</h2>
         {error && <div className="error">{error}</div>}
         {loading ? (

--- a/frontend/src/pages/ExerciseStats.jsx
+++ b/frontend/src/pages/ExerciseStats.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { fetchExerciseStats } from "../api/teacher";
 import "../index.css";
 
@@ -8,6 +8,7 @@ export default function ExerciseStats() {
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
@@ -29,6 +30,13 @@ export default function ExerciseStats() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>练习统计</h2>
         {error && <div className="error">{error}</div>}
         {loading ? (

--- a/frontend/src/pages/LessonList.jsx
+++ b/frontend/src/pages/LessonList.jsx
@@ -1,6 +1,6 @@
 // src/pages/LessonList.jsx
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { fetchLessonList } from "../api/teacher";
 import "../index.css";
 
@@ -8,6 +8,7 @@ export default function LessonList() {
   const [lessons, setLessons] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");  // 用于显示错误信息
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadLessons = async () => {
@@ -29,6 +30,13 @@ export default function LessonList() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>我的教案列表</h2>
         {error && <div className="error">{error}</div>}  {/* 错误显示 */}
         {loading ? (

--- a/frontend/src/pages/LessonPreview.jsx
+++ b/frontend/src/pages/LessonPreview.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 // src/pages/LessonPreview.jsx
 import React, { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { fetchLessonPreview, downloadCoursewarePdf } from "../api/teacher";  // 确保导入 downloadCoursewarePdf 函数
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";  // 用于支持 GitHub 风格的 Markdown（包括表格）
@@ -13,6 +13,7 @@ export default function LessonPreview() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");  // 用于显示错误信息
   const [downloadLoading, setDownloadLoading] = useState(false);  // 控制下载按钮的 loading 状态
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadPreview = async () => {
@@ -53,6 +54,13 @@ export default function LessonPreview() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>教案预览</h2>
         {error && <div className="error">{error}</div>}  {/* 错误显示 */}
         {loading ? (

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -20,6 +20,7 @@ export default function LoginPage() {
       const { access_token, role } = await login(form); // 登录成功返回token与role
       localStorage.setItem("token", access_token);
       localStorage.setItem("role", role);
+      localStorage.setItem("username", form.username);
 
       // 根据角色跳转
       if (role === "teacher") {

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { getSelfPractice, downloadSelfPracticePdf } from "../api/student";
 import "../index.css";
 
 export default function SelfPracticeDetail() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const [practice, setPractice] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -41,6 +42,13 @@ export default function SelfPracticeDetail() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>随练预览</h2>
         {error && <div className="error">{error}</div>}
         {loading ? (

--- a/frontend/src/pages/SelfPracticeList.jsx
+++ b/frontend/src/pages/SelfPracticeList.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { fetchSelfPracticeList } from "../api/student";
 import "../index.css";
 
 export default function SelfPracticeList() {
   const [list, setList] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
@@ -17,6 +18,13 @@ export default function SelfPracticeList() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>我的随练</h2>
         <table>
           <thead>

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -145,5 +145,6 @@ export default function StudentAiTeacher() {
         </div>
       </div>
     </div>
+    </div>
   );
 }

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -90,10 +90,18 @@ export default function StudentAiTeacher() {
 
   return (
     <div className="container">
-      <div className="card" style={{ display: "flex" }}>
-        <div style={{ width: "180px", marginRight: "1rem", borderRight: "1px solid #e5e5e5", paddingRight: "1rem" }}>
-          <button className="button" onClick={newChat} style={{ width: "100%" }}>新建聊天</button>
-          <ul style={{ listStyle: "none", padding: 0, marginTop: "1rem" }}>
+      <div className="card" style={{ display: "flex", flexDirection: "column" }}>
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
+        <div style={{ display: "flex" }}>
+          <div style={{ width: "180px", marginRight: "1rem", borderRight: "1px solid #e5e5e5", paddingRight: "1rem" }}>
+            <button className="button" onClick={newChat} style={{ width: "100%" }}>新建聊天</button>
+            <ul style={{ listStyle: "none", padding: 0, marginTop: "1rem" }}>
             {sessions.map((s, idx) => (
               <li key={s.id} style={{ display: "flex", alignItems: "center", marginBottom: "0.5rem" }}>
                 <span

--- a/frontend/src/pages/StudentChatHistory.jsx
+++ b/frontend/src/pages/StudentChatHistory.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
 import api from "../api/api";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import "../index.css";
 
 export default function StudentChatHistory() {
   const [history, setHistory] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const load = async () => {
@@ -26,6 +27,13 @@ export default function StudentChatHistory() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>历史记录</h2>
         <ul>
           {history.map((item) => (

--- a/frontend/src/pages/StudentHomeworkAnswer.jsx
+++ b/frontend/src/pages/StudentHomeworkAnswer.jsx
@@ -91,6 +91,13 @@ export default function StudentHomeworkAnswer() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>{exercise.subject}</h2>
         <div className="actions" style={{ flexWrap: "wrap" }}>
           {flat.map((q, idx) => (

--- a/frontend/src/pages/StudentHomeworkResult.jsx
+++ b/frontend/src/pages/StudentHomeworkResult.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import api from "../api/api";
 import "../index.css";
 
 export default function StudentHomeworkResult() {
   const { hw_id } = useParams();
+  const navigate = useNavigate();
   const [data, setData] = useState(null);
   const [error, setError] = useState("");
   const [activeId, setActiveId] = useState(null);
@@ -42,6 +43,13 @@ export default function StudentHomeworkResult() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>作业结果</h2>
         <div>总分：{score}</div>
         <div className="actions">

--- a/frontend/src/pages/StudentHomeworks.jsx
+++ b/frontend/src/pages/StudentHomeworks.jsx
@@ -22,6 +22,13 @@ export default function StudentHomeworks() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>我的作业</h2>
         <table>
           <thead>

--- a/frontend/src/pages/StudentPage.jsx
+++ b/frontend/src/pages/StudentPage.jsx
@@ -5,9 +5,27 @@ import "../index.css";
 
 export default function StudentPage() {
   const navigate = useNavigate();
+  const username = localStorage.getItem("username") || "";
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("role");
+    localStorage.removeItem("username");
+    navigate("/login");
+  };
   return (
     <div className="container">
       <div className="card">
+        <div style={{ textAlign: "right" }}>
+          您好，同学{username}
+          <button
+            className="button"
+            style={{ width: "auto", marginLeft: "1rem" }}
+            onClick={logout}
+          >
+            登出
+          </button>
+        </div>
         <h2>学生中心</h2>
         <div className="actions">
           <button className="button" onClick={() => navigate("homeworks")}>我的作业</button>

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { prepareLessonMarkdown, downloadCoursewarePdf, saveCourseware } from "../api/teacher";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";  // 引入 GitHub 风格的 Markdown 支持
@@ -11,6 +12,7 @@ export default function TeacherLesson() {
   const [error, setError] = useState("");
   const [saved, setSaved] = useState(false);
   const [cwId, setCwId] = useState(null);  // 用于保存课件的 ID
+  const navigate = useNavigate();
 
   const handleGenerate = async (e) => {
     e.preventDefault();
@@ -65,6 +67,13 @@ export default function TeacherLesson() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>教案备课</h2>
         {error && <div className="error">{error}</div>}
         {saved && <div className="success">教案已保存！</div>}

--- a/frontend/src/pages/TeacherPage.jsx
+++ b/frontend/src/pages/TeacherPage.jsx
@@ -5,6 +5,14 @@ import "../index.css";
 
 export default function TeacherPage() {
   const navigate = useNavigate();
+  const username = localStorage.getItem("username") || "";
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("role");
+    localStorage.removeItem("username");
+    navigate("/login");
+  };
 
   const handlePrepare = () => {
     navigate("/teacher/lesson");  // 跳转到备课页面
@@ -29,6 +37,16 @@ export default function TeacherPage() {
   return (
     <div className="container">
       <div className="card">
+        <div style={{ textAlign: "right" }}>
+          您好，教师{username}
+          <button
+            className="button"
+            style={{ width: "auto", marginLeft: "1rem" }}
+            onClick={logout}
+          >
+            登出
+          </button>
+        </div>
         <h2>教师中心</h2>
         <div className="actions">
           <button className="button" onClick={handlePrepare}>

--- a/frontend/src/pages/TeacherStudentDetail.jsx
+++ b/frontend/src/pages/TeacherStudentDetail.jsx
@@ -38,6 +38,13 @@ export default function TeacherStudentDetail() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>学生 {sid} 学情</h2>
         {error && <div className="error">{error}</div>}
         <div className="markdown-preview" style={{ minHeight: '6rem' }}>

--- a/frontend/src/pages/TeacherStudentHomeworkDetail.jsx
+++ b/frontend/src/pages/TeacherStudentHomeworkDetail.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { fetchStudentHomeworkDetail } from '../api/teacher';
 import '../index.css';
 
 export default function TeacherStudentHomeworkDetail() {
   const { sid, hw_id } = useParams();
+  const navigate = useNavigate();
   const [data, setData] = useState(null);
   const [error, setError] = useState('');
   const [activeId, setActiveId] = useState(null);
@@ -36,6 +37,13 @@ export default function TeacherStudentHomeworkDetail() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>作业 {hw_id} 详情</h2>
         <div>总分：{score}</div>
         <div className="actions">

--- a/frontend/src/pages/TeacherStudents.jsx
+++ b/frontend/src/pages/TeacherStudents.jsx
@@ -29,6 +29,13 @@ export default function TeacherStudents() {
   return (
     <div className="container">
       <div className="card">
+        <button
+          className="button"
+          style={{ width: "auto", marginBottom: "1rem" }}
+          onClick={() => navigate(-1)}
+        >
+          返回
+        </button>
         <h2>学生列表</h2>
         {error && <div className="error">{error}</div>}
         {loading ? (


### PR DESCRIPTION
## Summary
- show greeting and logout button on teacher/student center pages
- store username on login
- add back buttons across teacher and student feature pages

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860da9953d8832284a0e15397762f42