### PR TITLE
Fix sidebar button overlap and logout position

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -189,3 +189,11 @@ td {
   left: 1rem;
   z-index: 1100;
 }
+
+.toggle-btn.shifted {
+  left: calc(200px + 2rem);
+}
+
+.logout-btn {
+  margin-bottom: 1rem;
+}

--- a/frontend/src/pages/StudentLayout.jsx
+++ b/frontend/src/pages/StudentLayout.jsx
@@ -22,7 +22,7 @@ export default function StudentLayout() {
   return (
     <>
       <button
-        className="button toggle-btn"
+        className={`button toggle-btn${open ? " shifted" : ""}`}
         onClick={() => setOpen(!open)}
         style={{ width: "auto" }}
       >
@@ -35,7 +35,7 @@ export default function StudentLayout() {
         <button className="button" onClick={() => nav("/student/evaluate")}>评测助手</button>
         <button className="button" onClick={() => nav("/student/self_practice")}>我的随练</button>
         <div style={{ flex: 1 }} />
-        <button className="button" onClick={logout}>登出</button>
+        <button className="button logout-btn" onClick={logout}>登出</button>
       </div>
       <div>
         <Outlet />

--- a/frontend/src/pages/TeacherLayout.jsx
+++ b/frontend/src/pages/TeacherLayout.jsx
@@ -22,7 +22,7 @@ export default function TeacherLayout() {
   return (
     <>
       <button
-        className="button toggle-btn"
+        className={`button toggle-btn${open ? " shifted" : ""}`}
         onClick={() => setOpen(!open)}
         style={{ width: "auto" }}
       >
@@ -36,7 +36,7 @@ export default function TeacherLayout() {
         <button className="button" onClick={() => nav("/teacher/exercise/list")}>练习列表</button>
         <button className="button" onClick={() => nav("/teacher/students")}>学情数据</button>
         <div style={{ flex: 1 }} />
-        <button className="button" onClick={logout}>登出</button>
+        <button className="button logout-btn" onClick={logout}>登出</button>
       </div>
       <div>
         <Outlet />


### PR DESCRIPTION
## Summary
- move toggle button when sidebar is open
- add margin for logout button

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686168d35bdc83228b7cad17e92ca41f