### PR TITLE
Add admin panel backend and UI

### DIFF
--- a/backend/create_db.sql
+++ b/backend/create_db.sql
@@ -227,7 +227,7 @@ CREATE TABLE `practice` (
 
 LOCK TABLES `user` WRITE;
 /*!40000 ALTER TABLE `user` DISABLE KEYS */;
-INSERT INTO `user` VALUES (1,'testuser','pass123',1),(2,'stu1','123',1),(3,'tea1','123',2),(4,'tea2','123',2);
+INSERT INTO `user` VALUES (1,'testuser','pass123',1),(2,'stu1','123',1),(3,'tea1','123',2),(4,'tea2','123',2),(5,'mng1','123',3);
 /*!40000 ALTER TABLE `user` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from backend.routers.exercise_router import router as exercise_router
 from backend.routers.homework_router import router as homework_router
 from backend.routers.teacher_router import router as teacher_student_router
 from backend.routers.student_router import router, router_practice, router_analysis
+from backend.routers.admin_router import router as admin_router
 
 app = FastAPI()
 app.add_middleware(
@@ -32,6 +33,7 @@ app.include_router(teacher_student_router)
 app.include_router(router)
 app.include_router(router_practice)
 app.include_router(router_analysis)
+app.include_router(admin_router)
 
 app.mount("/static", StaticFiles(directory="backend/static"), name="static")
 
@@ -42,6 +44,6 @@ async def ping():
 @app.get("/{full_path:path}")
 async def spa_fallback(full_path:str, request:Request):
     if full_path.startswith(("docs","openapi.json","redoc",
-                             "static","auth","lesson","teacher","student","ping")):
+                             "static","auth","lesson","teacher","student","admin","ping")):
         raise HTTPException(404)
     return FileResponse("backend/static/index.html")

--- a/backend/routers/admin_router.py
+++ b/backend/routers/admin_router.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+from sqlalchemy import func
+from pydantic import BaseModel
+
+from backend.auth import get_current_user
+from backend.config import engine
+from backend.models import (
+    User, Role, Courseware, Exercise, Homework, Submission,
+    ChatHistory, ChatSession, ChatMessage, Practice
+)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class UserInfo(BaseModel):
+    id: int
+    username: str
+    role: str
+
+    class Config:
+        from_attributes = True
+
+
+class CoursewareMeta(BaseModel):
+    id: int
+    topic: str
+    teacher_id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+@router.get("/users", response_model=List[UserInfo])
+def list_users(role: Optional[str] = None, current: User = Depends(get_current_user)):
+    if not current.role or current.role.name != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限管理员访问")
+    with Session(engine) as sess:
+        stmt = select(User, Role).join(Role, User.role_id == Role.id)
+        if role:
+            stmt = stmt.where(Role.name == role)
+        rows = sess.exec(stmt).all()
+        return [UserInfo(id=u.id, username=u.username, role=r.name) for u, r in rows]
+
+
+@router.get("/users/{uid}", response_model=UserInfo)
+def get_user(uid: int, current: User = Depends(get_current_user)):
+    if not current.role or current.role.name != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限管理员访问")
+    with Session(engine) as sess:
+        user = sess.get(User, uid)
+        if not user:
+            raise HTTPException(status_code=404, detail="用户不存在")
+        role = sess.get(Role, user.role_id)
+        rname = role.name if role else ""
+        return UserInfo(id=user.id, username=user.username, role=rname)
+
+
+@router.delete("/users/{uid}")
+def delete_user(uid: int, current: User = Depends(get_current_user)):
+    if not current.role or current.role.name != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限管理员访问")
+    with Session(engine) as sess:
+        user = sess.get(User, uid)
+        if not user:
+            raise HTTPException(status_code=404, detail="用户不存在")
+        # 删除与用户相关的记录
+        for cw in sess.exec(select(Courseware).where(Courseware.teacher_id == uid)):
+            sess.delete(cw)
+        for ex in sess.exec(select(Exercise).where(Exercise.teacher_id == uid)):
+            # 删除作业及提交
+            for hw in sess.exec(select(Homework).where(Homework.exercise_id == ex.id)):
+                for sub in sess.exec(select(Submission).where(Submission.homework_id == hw.id)):
+                    sess.delete(sub)
+                sess.delete(hw)
+            sess.delete(ex)
+        for sub in sess.exec(select(Submission).where(Submission.student_id == uid)):
+            sess.delete(sub)
+        for ch in sess.exec(select(ChatHistory).where(ChatHistory.student_id == uid)):
+            sess.delete(ch)
+        for s in sess.exec(select(ChatSession).where(ChatSession.student_id == uid)):
+            for m in sess.exec(select(ChatMessage).where(ChatMessage.session_id == s.id)):
+                sess.delete(m)
+            sess.delete(s)
+        for p in sess.exec(select(Practice).where(Practice.student_id == uid)):
+            sess.delete(p)
+        sess.delete(user)
+        sess.commit()
+        return {"status": "ok"}
+
+
+@router.get("/coursewares", response_model=List[CoursewareMeta])
+def list_coursewares(current: User = Depends(get_current_user)):
+    if not current.role or current.role.name != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限管理员访问")
+    with Session(engine) as sess:
+        stmt = select(Courseware)
+        items = sess.exec(stmt).all()
+        return [CoursewareMeta(id=c.id, topic=c.topic, teacher_id=c.teacher_id, created_at=c.created_at) for c in items]
+
+
+@router.post("/courseware/{cid}/share")
+def share_courseware(cid: int, current: User = Depends(get_current_user)):
+    if not current.role or current.role.name != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限管理员访问")
+    with Session(engine) as sess:
+        cw = sess.get(Courseware, cid)
+        if not cw:
+            raise HTTPException(404, "课件不存在")
+        teachers = sess.exec(select(User).join(Role).where(Role.name == "teacher")).all()
+        for t in teachers:
+            topic = f"{cw.topic}-public"
+            new_cw = Courseware(
+                teacher_id=t.id,
+                topic=topic,
+                markdown=cw.markdown,
+                pdf=cw.pdf
+            )
+            sess.add(new_cw)
+        sess.commit()
+        return {"status": "shared"}
+
+
+@router.get("/dashboard")
+def dashboard(current: User = Depends(get_current_user)):
+    if not current.role or current.role.name != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限管理员访问")
+    today = datetime.utcnow().date()
+    week_ago = today - timedelta(days=7)
+    with Session(engine) as sess:
+        teacher_count = sess.exec(
+            select(func.count()).select_from(User).join(Role).where(Role.name == "teacher")
+        ).one()
+        student_count = sess.exec(
+            select(func.count()).select_from(User).join(Role).where(Role.name == "student")
+        ).one()
+        cw_count = sess.exec(select(func.count()).select_from(Courseware)).one()
+        ex_count = sess.exec(select(func.count()).select_from(Exercise)).one()
+        teacher_today = sess.exec(
+            select(func.count()).select_from(Exercise).where(Exercise.created_at >= today)
+        ).one()
+        student_today = sess.exec(
+            select(func.count()).select_from(Submission).where(Submission.submitted_at >= today)
+        ).one()
+        teacher_week = sess.exec(
+            select(func.count()).select_from(Exercise).where(Exercise.created_at >= week_ago)
+        ).one()
+        student_week = sess.exec(
+            select(func.count()).select_from(Submission).where(Submission.submitted_at >= week_ago)
+        ).one()
+    return {
+        "teacher_count": teacher_count,
+        "student_count": student_count,
+        "courseware_count": cw_count,
+        "exercise_count": ex_count,
+        "teacher_usage_today": teacher_today,
+        "student_usage_today": student_today,
+        "teacher_usage_week": teacher_week,
+        "student_usage_week": student_week,
+    }

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,0 +1,31 @@
+import api from './api';
+
+export async function fetchUsers(role) {
+  const resp = await api.get('/admin/users', { params: { role } });
+  return resp.data;
+}
+
+export async function fetchUser(uid) {
+  const resp = await api.get(`/admin/users/${uid}`);
+  return resp.data;
+}
+
+export async function deleteUser(uid) {
+  const resp = await api.delete(`/admin/users/${uid}`);
+  return resp.data;
+}
+
+export async function fetchCoursewares() {
+  const resp = await api.get('/admin/coursewares');
+  return resp.data;
+}
+
+export async function shareCourseware(cid) {
+  const resp = await api.post(`/admin/courseware/${cid}/share`);
+  return resp.data;
+}
+
+export async function fetchDashboard() {
+  const resp = await api.get('/admin/dashboard');
+  return resp.data;
+}

--- a/frontend/src/pages/AdminCoursewares.jsx
+++ b/frontend/src/pages/AdminCoursewares.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { fetchCoursewares, shareCourseware } from '../api/admin';
+import '../index.css';
+
+export default function AdminCoursewares() {
+  const [list, setList] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchCoursewares();
+      setList(data);
+    } catch (err) {
+      setError('加载失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleShare = async (cid) => {
+    try {
+      await shareCourseware(cid);
+      alert('已共享');
+    } catch (err) {
+      alert('操作失败');
+    }
+  };
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h2>课件管理</h2>
+        {error && <div className="error">{error}</div>}
+        {loading ? (
+          <div>加载中...</div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>主题</th>
+                <th>教师</th>
+                <th>创建时间</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map((c) => (
+                <tr key={c.id}>
+                  <td>{c.id}</td>
+                  <td>{c.topic}</td>
+                  <td>{c.teacher_id}</td>
+                  <td>{c.created_at}</td>
+                  <td>
+                    <button className="button" onClick={() => handleShare(c.id)}>
+                      共享
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,10 +1,42 @@
-import React from "react";
+import React, { useEffect, useState } from 'react';
+import { fetchDashboard } from '../api/admin';
+import '../index.css';
 
 export default function AdminDashboard() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const d = await fetchDashboard();
+        setData(d);
+      } catch (err) {
+        setError('加载失败');
+      }
+    };
+    load();
+  }, []);
+
+  if (error) {
+    return <div className="container"><div className="card">{error}</div></div>;
+  }
+  if (!data) {
+    return <div className="container"><div className="card">加载中...</div></div>;
+  }
   return (
-    <div>
-      <h1>管理员—管理面板</h1>
-      {/* TODO: 管理员功能入口 */}
+    <div className="container">
+      <div className="card">
+        <h2>数据概览</h2>
+        <ul>
+          <li>教师数量: {data.teacher_count}</li>
+          <li>学生数量: {data.student_count}</li>
+          <li>课件数量: {data.courseware_count}</li>
+          <li>练习数量: {data.exercise_count}</li>
+          <li>教师今日使用次数: {data.teacher_usage_today}</li>
+          <li>学生今日使用次数: {data.student_usage_today}</li>
+        </ul>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import '../index.css';
+
+export default function AdminLayout() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const username = localStorage.getItem('username') || '';
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('role');
+    localStorage.removeItem('username');
+    navigate('/login');
+  };
+
+  const nav = (path) => {
+    navigate(path);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        className={`button toggle-btn${open ? ' shifted' : ''}`}
+        onClick={() => setOpen(!open)}
+        style={{ width: 'auto' }}
+      >
+        菜单
+      </button>
+      <div className={`sidebar${open ? ' open' : ''}`}>
+        <div style={{ marginBottom: '1rem' }}>您好，管理员{username}</div>
+        <button className="button" onClick={() => nav('/admin/users')}>用户管理</button>
+        <button className="button" onClick={() => nav('/admin/coursewares')}>课件管理</button>
+        <button className="button" onClick={() => nav('/admin/dashboard')}>数据概览</button>
+        <div style={{ flex: 1 }} />
+        <button className="button logout-btn" onClick={logout}>登出</button>
+      </div>
+      <div>
+        <Outlet />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,14 +1,20 @@
-// src/pages/AdminPage.jsx
-import React from "react";
-import "../index.css";
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import AdminLayout from './AdminLayout';
+import AdminUsers from './AdminUsers';
+import AdminCoursewares from './AdminCoursewares';
+import AdminDashboard from './AdminDashboard';
 
 export default function AdminPage() {
   return (
-    <div className="container">
-      <div className="card">
-        <h2>管理员页面</h2>
-        <p>此处预留用户管理、课件资源管理和数据概览功能。</p>
-      </div>
-    </div>
+    <Routes>
+      <Route element={<AdminLayout />}>
+        <Route path="users" element={<AdminUsers />} />
+        <Route path="coursewares" element={<AdminCoursewares />} />
+        <Route path="dashboard" element={<AdminDashboard />} />
+        <Route index element={<Navigate to="dashboard" replace />} />
+        <Route path="*" element={<Navigate to="dashboard" replace />} />
+      </Route>
+    </Routes>
   );
 }

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { fetchUsers, deleteUser } from '../api/admin';
+import '../index.css';
+
+export default function AdminUsers() {
+  const [list, setList] = useState([]);
+  const [role, setRole] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = async (r) => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchUsers(r);
+      setList(data);
+    } catch (err) {
+      setError('加载失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load(role);
+  }, [role]);
+
+  const handleDelete = async (uid) => {
+    if (!window.confirm('确认删除该用户及其数据吗？')) return;
+    try {
+      await deleteUser(uid);
+      load(role);
+    } catch (err) {
+      alert('删除失败');
+    }
+  };
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h2>用户管理</h2>
+        <div style={{ marginBottom: '1rem' }}>
+          <select value={role} onChange={(e) => setRole(e.target.value)}>
+            <option value="">全部</option>
+            <option value="admin">管理员</option>
+            <option value="teacher">教师</option>
+            <option value="student">学生</option>
+          </select>
+        </div>
+        {error && <div className="error">{error}</div>}
+        {loading ? (
+          <div>加载中...</div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>用户名</th>
+                <th>角色</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map((u) => (
+                <tr key={u.id}>
+                  <td>{u.id}</td>
+                  <td>{u.username}</td>
+                  <td>{u.role}</td>
+                  <td>
+                    <button className="button" onClick={() => handleDelete(u.id)}>
+                      删除
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -25,6 +25,8 @@ export default function LoginPage() {
       // 根据角色跳转
       if (role === "teacher") {
         navigate("/teacher");
+      } else if (role === "admin") {
+        navigate("/admin");
       } else {
         navigate("/student");
       }

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -87,7 +87,14 @@ export default function AppRouter() {
         <Route path="*" element={<Navigate to="homeworks" replace />} />
       </Route>
       {/* 管理员视图 */}
-      <Route path="/admin/*" element={<AdminPage />} />
+      <Route
+        path="/admin/*"
+        element={
+          <ProtectedRoute allowedRoles={["admin"]}>
+            <AdminPage />
+          </ProtectedRoute>
+        }
+      />
       
       <Route path="*" element={<Navigate to="/login" replace />} />  
     </Routes>


### PR DESCRIPTION
## Summary
- implement `/admin` router in backend for user management, courseware sharing and dashboard stats
- register the router in FastAPI app
- add admin API helpers and React pages
- secure admin routes in frontend router

## Testing
- `python -m py_compile backend/routers/admin_router.py backend/main.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68709252508883229391fd9d50fd732e