### PR TITLE
Fix exercise pdf generation and saving

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -99,6 +99,8 @@ def get_current_user(
     user = sess.get(User, int(user_id))
     if not user:
         raise credentials_exception
+    # Ensure role relationship is loaded before session closes
+    _ = user.role
     return user
 
 @router.get("/me")

--- a/backend/routers/exercise_router.py
+++ b/backend/routers/exercise_router.py
@@ -119,7 +119,10 @@ def api_assign(ex_id: int, user: User = Depends(get_current_user)):
     ex = get_exercise(ex_id)
     if not ex or ex.teacher_id != user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权布置")
-    return assign_homework(ex_id)
+    try:
+        return assign_homework(ex_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="未找到练习")
 
 
 @router.get("/{ex_id}/stats")

--- a/backend/routers/exercise_router.py
+++ b/backend/routers/exercise_router.py
@@ -12,7 +12,7 @@ from backend.services.exercise_service import (
     preview_exercise, save_exercise, save_and_assign_exercise,
     get_exercise, get_homework, list_exercises,
     download_questions_pdf, download_answers_pdf,
-    assign_homework, stats_for_exercise
+    assign_homework, stats_for_exercise, render_exercise_pdf
 )
 from backend.auth import get_current_user
 from backend.models import User
@@ -26,17 +26,25 @@ class SaveExerciseRequest(BaseModel):
     answers: dict
 
 
-@router.post("/generate", response_model=ExercisePreviewOut)
+@router.post("/generate")
 def api_generate(req: GenerateExerciseRequest, user: User = Depends(get_current_user)):
     if user.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
-    return preview_exercise(
+    data = preview_exercise(
         topic=req.topic,
         num_mcq=req.num_mcq,
         num_fill_blank=req.num_fill_blank,
         num_short_answer=req.num_short_answer,
         num_programming=req.num_programming,
     )
+    if req.export_pdf:
+        pdf = render_exercise_pdf(f"练习：{req.topic}", data.get("questions", []), answers=data.get("answers", {}))
+        raw = f"exercise_{req.topic}.pdf"
+        headers = {
+            "Content-Disposition": f"attachment; filename=exercise.pdf; filename*=UTF-8''{quote(raw)}"
+        }
+        return StreamingResponse(io.BytesIO(pdf), media_type="application/pdf", headers=headers)
+    return data
 
 
 @router.post("/save", response_model=ExerciseOut)

--- a/backend/schemas/exercise_schema.py
+++ b/backend/schemas/exercise_schema.py
@@ -9,6 +9,7 @@ class GenerateExerciseRequest(BaseModel):
     num_fill_blank: int = 0
     num_short_answer: int = 0
     num_programming: int = 0
+    export_pdf: bool = False
 
 
 class QuestionItem(BaseModel):

--- a/backend/services/exercise_service.py
+++ b/backend/services/exercise_service.py
@@ -4,19 +4,32 @@ from typing import Dict, Any, List
 from io import BytesIO
 
 from sqlmodel import Session, select
+from sqlalchemy.orm import selectinload
 from reportlab.lib.pagesizes import letter
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.enums import TA_CENTER, TA_LEFT
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+from reportlab.pdfbase.ttfonts import TTFont
+from pathlib import Path
 
 from backend.models import Exercise, Homework
 from backend.utils.deepseek_client import call_deepseek_api
 from backend.config import engine
 
-# 注册 ReportLab 自带的 CJK 字体
-pdfmetrics.registerFont(UnicodeCIDFont('STSong-Light'))
+# 尝试加载系统中可用的中文字体，优先使用 NotoSansCJK
+DEFAULT_FONT = "STSong-Light"
+try:
+    noto = Path("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc")
+    if noto.exists():
+        pdfmetrics.registerFont(TTFont("NotoSansCJK", str(noto)))
+        DEFAULT_FONT = "NotoSansCJK"
+except Exception:
+    pass
+
+# 始终注册内置的 STSong 作为后备
+pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
 
 
 def _parse_model_response(resp: Dict[str, Any]) -> Dict[str, Any]:
@@ -49,7 +62,7 @@ def preview_exercise(
 
     prompt = (
         f"请根据主题“{topic}”{''.join(parts)}\n\n"
-        "请以 JSON 格式返回：questions（列表，每项 {\"type\":..., \"items\":[...] }），"
+        '请以 JSON 格式返回：questions（列表，每项 {"type":..., "items":[...] }），'
         "answers（对象，键为题目 id，值为参考答案）。"
     )
     resp = call_deepseek_api(prompt)
@@ -105,12 +118,9 @@ def save_and_assign_exercise(
 
         # 重新加载，预加载 exercise 关系
         hw = sess.exec(
-            select(Homework).options(
-                # 这里需要在 Homework model 上定义 relationship to Exercise
-                # e.g. exercise = Relationship(back_populates="homeworks")
-                # Raiload exercise 字段
-                Homework.exercise
-            ).where(Homework.id == hw.id)
+            select(Homework)
+            .options(selectinload(Homework.exercise))
+            .where(Homework.id == hw.id)
         ).one()
         return hw
 
@@ -123,9 +133,9 @@ def get_exercise(ex_id: int) -> Exercise:
 def get_homework(homework_id: int) -> Homework:
     with Session(engine) as sess:
         return sess.exec(
-            select(Homework).options(Homework.exercise).where(
-                Homework.id == homework_id
-            )
+            select(Homework)
+            .options(selectinload(Homework.exercise))
+            .where(Homework.id == homework_id)
         ).one_or_none()
 
 
@@ -139,60 +149,76 @@ def list_exercises(teacher_id: int) -> List[Exercise]:
         return sess.exec(stmt).all()
 
 
-def _build_pdf(buffer: BytesIO, title: str, blocks: List[Dict[str, Any]], answers: Dict[str, Any] = None):
+def _build_pdf(
+    buffer: BytesIO,
+    title: str,
+    blocks: List[Dict[str, Any]],
+    answers: Dict[str, Any] = None,
+):
     """
     用 ReportLab Platypus 构建 PDF，使用内置 CJK 字体。
     """
     doc = SimpleDocTemplate(
-        buffer, pagesize=letter,
-        leftMargin=50, rightMargin=50,
-        topMargin=60, bottomMargin=60
+        buffer,
+        pagesize=letter,
+        leftMargin=50,
+        rightMargin=50,
+        topMargin=60,
+        bottomMargin=60,
     )
     styles = getSampleStyleSheet()
     normal = ParagraphStyle(
-        'Normal_CN',
-        parent=styles['Normal'],
-        fontName='STSong-Light',
+        "Normal_CN",
+        parent=styles["Normal"],
+        fontName=DEFAULT_FONT,
         fontSize=12,
         leading=16,
-        bulletFontName='Helvetica',  # bullet 字符使用基础字体，避免乱码
+        bulletFontName="Helvetica",  # bullet 字符使用基础字体，避免乱码
     )
     title_style = ParagraphStyle(
-        'Title_CN',
-        parent=styles['Heading1'],
-        fontName='STSong-Light',
+        "Title_CN",
+        parent=styles["Heading1"],
+        fontName=DEFAULT_FONT,
         fontSize=18,
         alignment=TA_CENTER,
         spaceAfter=18,
     )
     qtype = ParagraphStyle(
-        'QType_CN',
-        parent=styles['Heading2'],
-        fontName='STSong-Light',
+        "QType_CN",
+        parent=styles["Heading2"],
+        fontName=DEFAULT_FONT,
         fontSize=14,
         alignment=TA_LEFT,
         spaceBefore=12,
         spaceAfter=6,
-        bulletFontName='Helvetica',
+        bulletFontName="Helvetica",
     )
 
     story: List[Any] = [Paragraph(title, title_style)]
     for idx, block in enumerate(blocks, start=1):
-        story.append(Paragraph(f"{idx}. { (block.get('type') or '').replace('_',' ').title() }", qtype))
-        for item in block.get('items') or []:
-            story.append(Paragraph(item.get('question', ''), normal, bulletText='\u2022'))
-            story.append(Spacer(1,4))
-            for opt in item.get('options') or []:
-                story.append(Paragraph(opt, normal, bulletText='-'))
-            story.append(Spacer(1,8))
+        story.append(
+            Paragraph(
+                f"{idx}. { (block.get('type') or '').replace('_',' ').title() }", qtype
+            )
+        )
+        for item in block.get("items") or []:
+            story.append(
+                Paragraph(item.get("question", ""), normal, bulletText="\u2022")
+            )
+            story.append(Spacer(1, 4))
+            for opt in item.get("options") or []:
+                story.append(Paragraph(opt, normal, bulletText="-"))
+            story.append(Spacer(1, 8))
             if answers is not None:
-                ans = answers.get(str(item.get('id')), '')
+                ans = answers.get(str(item.get("id")), "")
                 story.append(Paragraph(f"答案：{ans}", normal))
-                story.append(Spacer(1,12))
+                story.append(Spacer(1, 12))
     doc.build(story)
 
 
-def render_exercise_pdf(title: str, blocks: List[Dict[str, Any]], answers: Dict[str, Any] | None = None) -> bytes:
+def render_exercise_pdf(
+    title: str, blocks: List[Dict[str, Any]], answers: Dict[str, Any] | None = None
+) -> bytes:
     """Helper to render questions/answers into a PDF."""
     buf = BytesIO()
     _build_pdf(buf, title, blocks, answers=answers)
@@ -223,18 +249,21 @@ def assign_homework(exercise_id: int) -> Homework:
         sess.refresh(hw)
 
         hw = sess.exec(
-            select(Homework).options(Homework.exercise).where(Homework.id == hw.id)
+            select(Homework)
+            .options(selectinload(Homework.exercise))
+            .where(Homework.id == hw.id)
         ).one()
         return hw
 
 
 def stats_for_exercise(exercise_id: int) -> Dict[str, Any]:
     from backend.models import Submission
+
     with Session(engine) as sess:
         subs = sess.exec(
-            select(Submission).join(Homework, Submission.homework_id == Homework.id).where(
-                Homework.exercise_id == exercise_id
-            )
+            select(Submission)
+            .join(Homework, Submission.homework_id == Homework.id)
+            .where(Homework.exercise_id == exercise_id)
         ).all()
         total = len(subs)
         avg = sum(s.score for s in subs) / total if total else 0.0

--- a/backend/services/exercise_service.py
+++ b/backend/services/exercise_service.py
@@ -169,6 +169,13 @@ def _build_pdf(buffer: BytesIO, title: str, blocks: List[Dict[str, Any]], answer
     doc.build(story)
 
 
+def render_exercise_pdf(title: str, blocks: List[Dict[str, Any]], answers: Dict[str, Any] | None = None) -> bytes:
+    """Helper to render questions/answers into a PDF."""
+    buf = BytesIO()
+    _build_pdf(buf, title, blocks, answers=answers)
+    return buf.getvalue()
+
+
 def download_questions_pdf(ex: Exercise) -> bytes:
     buf = BytesIO()
     _build_pdf(buf, f"练习 #{ex.id} 题目", ex.prompt or [], answers=None)


### PR DESCRIPTION
## Summary
- support `export_pdf` flag when generating exercises
- allow preloaded user role during authentication
- expose helper to render exercise PDFs
- return generated PDF in `/teacher/exercise/generate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c8a54888832298eba3d1d1210896