### PR TITLE
Enhance admin features with login stats and editing

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -8,7 +8,7 @@ import jwt
 from pydantic import BaseModel
 
 from backend.config import settings, engine
-from backend.models import User, Role
+from backend.models import User, Role, LoginEvent
 
 router = APIRouter(tags=["auth"])
 
@@ -73,6 +73,9 @@ def login_for_access_token(
     # 获取角色名
     db_role = sess.get(Role, user.role_id)
     role_name = db_role.name if db_role else ""
+    # 记录登录事件
+    sess.add(LoginEvent(user_id=user.id))
+    sess.commit()
     return {
         "access_token": token,
         "token_type": "bearer",

--- a/backend/models.py
+++ b/backend/models.py
@@ -87,6 +87,8 @@ class Courseware(SQLModel, table=True):
         sa_column=Column("pdf", LargeBinary)
     )
     created_at: datetime = Field(default_factory=datetime.utcnow)
+    prep_start: Optional[datetime] = Field(default=None)
+    prep_end: Optional[datetime] = Field(default=None)
 
     teacher: User = Relationship(back_populates="coursewares")
 
@@ -145,3 +147,13 @@ class Practice(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
     student: "User" = Relationship(back_populates="practices")
+
+
+class LoginEvent(SQLModel, table=True):
+    __tablename__ = "login_event"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", nullable=False)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    user: User = Relationship()

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -25,6 +25,21 @@ export async function shareCourseware(cid) {
   return resp.data;
 }
 
+export async function downloadCourseware(cid) {
+  const resp = await api.get(`/admin/courseware/${cid}/download`, { responseType: 'blob' });
+  return resp.data;
+}
+
+export async function fetchCoursewarePreview(cid) {
+  const resp = await api.get(`/admin/courseware/${cid}/preview`);
+  return resp.data;
+}
+
+export async function updateCourseware(cid, markdown) {
+  const resp = await api.post(`/admin/courseware/${cid}/update`, { markdown });
+  return resp.data;
+}
+
 export async function fetchDashboard() {
   const resp = await api.get('/admin/dashboard');
   return resp.data;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,6 +58,8 @@ html, body, #root {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin-top: 1rem;
   text-align: center;
+  text-decoration: none;
+  display: block;
 }
 
 .button:disabled {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -197,3 +197,25 @@ td {
 .logout-btn {
   margin-bottom: 1rem;
 }
+
+/* Layout for admin courseware editing */
+.edit-layout {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.edit-input {
+  flex: 1;
+  min-height: 60vh;
+}
+
+.preview-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.preview-column .actions {
+  margin-top: 0;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,6 +57,7 @@ html, body, #root {
   transition: background-color 0.3s ease, transform 0.2s ease;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin-top: 1rem;
+  text-align: center;
 }
 
 .button:disabled {
@@ -205,15 +206,26 @@ td {
   flex-wrap: wrap;
 }
 
+.edit-container {
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+.wide-card {
+  max-width: none;
+  width: 100%;
+}
+
 .edit-input {
   flex: 1;
-  min-height: 60vh;
+  min-height: 75vh;
 }
 
 .preview-column {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 75vh;
 }
 
 .preview-column .actions {

--- a/frontend/src/pages/AdminCoursewareEdit.jsx
+++ b/frontend/src/pages/AdminCoursewareEdit.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { fetchCoursewarePreview, updateCourseware, downloadCourseware } from '../api/admin';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import '../index.css';
+
+export default function AdminCoursewareEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [markdown, setMarkdown] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchCoursewarePreview(id);
+        setMarkdown(data.markdown || '');
+      } catch (err) {
+        setError('加载失败');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleSave = async () => {
+    try {
+      await updateCourseware(id, markdown);
+      alert('已保存');
+    } catch (err) {
+      alert('保存失败');
+    }
+  };
+
+  const handleDownload = async () => {
+    try {
+      const blob = await downloadCourseware(id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `lesson_${id}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert('下载失败');
+    }
+  };
+
+  if (loading) {
+    return <div className="container"><div className="card">加载中...</div></div>;
+  }
+
+  return (
+    <div className="container">
+      <div className="card">
+        <button className="button" style={{ width: 'auto', marginBottom: '1rem' }} onClick={() => navigate(-1)}>返回</button>
+        {error && <div className="error">{error}</div>}
+        <textarea className="input" style={{ height: '200px' }} value={markdown} onChange={e => setMarkdown(e.target.value)} />
+        <div className="actions">
+          <button className="button" onClick={handleSave}>保存</button>
+          <button className="button" onClick={handleDownload}>下载 PDF</button>
+        </div>
+        <div className="markdown-preview">
+          <ReactMarkdown children={markdown} remarkPlugins={[remarkGfm]} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminCoursewareEdit.jsx
+++ b/frontend/src/pages/AdminCoursewareEdit.jsx
@@ -56,8 +56,8 @@ export default function AdminCoursewareEdit() {
   }
 
   return (
-    <div className="container">
-      <div className="card">
+    <div className="container edit-container">
+      <div className="card wide-card">
         <button className="button" style={{ width: 'auto', marginBottom: '1rem' }} onClick={() => navigate(-1)}>返回</button>
         {error && <div className="error">{error}</div>}
         <div className="edit-layout">

--- a/frontend/src/pages/AdminCoursewareEdit.jsx
+++ b/frontend/src/pages/AdminCoursewareEdit.jsx
@@ -60,13 +60,21 @@ export default function AdminCoursewareEdit() {
       <div className="card">
         <button className="button" style={{ width: 'auto', marginBottom: '1rem' }} onClick={() => navigate(-1)}>返回</button>
         {error && <div className="error">{error}</div>}
-        <textarea className="input" style={{ height: '200px' }} value={markdown} onChange={e => setMarkdown(e.target.value)} />
-        <div className="actions">
-          <button className="button" onClick={handleSave}>保存</button>
-          <button className="button" onClick={handleDownload}>下载 PDF</button>
-        </div>
-        <div className="markdown-preview">
-          <ReactMarkdown children={markdown} remarkPlugins={[remarkGfm]} />
+        <div className="edit-layout">
+          <textarea
+            className="input edit-input"
+            value={markdown}
+            onChange={e => setMarkdown(e.target.value)}
+          />
+          <div className="preview-column">
+            <div className="actions" style={{ marginTop: 0 }}>
+              <button className="button" onClick={handleSave}>保存</button>
+              <button className="button" onClick={handleDownload}>下载 PDF</button>
+            </div>
+            <div className="markdown-preview" style={{ marginTop: '1rem' }}>
+              <ReactMarkdown children={markdown} remarkPlugins={[remarkGfm]} />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/AdminCoursewares.jsx
+++ b/frontend/src/pages/AdminCoursewares.jsx
@@ -91,7 +91,11 @@ export default function AdminCoursewares() {
                     >
                       下载
                     </button>
-                    <Link className="button" style={{ marginTop: '0.5rem', display: 'block' }} to={`/admin/courseware/${c.id}/edit`}>
+                    <Link
+                      className="button"
+                      style={{ marginTop: '0.5rem' }}
+                      to={`/admin/courseware/${c.id}/edit`}
+                    >
                       编辑
                     </Link>
                   </td>

--- a/frontend/src/pages/AdminCoursewares.jsx
+++ b/frontend/src/pages/AdminCoursewares.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { fetchCoursewares, shareCourseware } from '../api/admin';
+import { fetchCoursewares, shareCourseware, downloadCourseware } from '../api/admin';
+import { Link } from 'react-router-dom';
 import '../index.css';
 
 export default function AdminCoursewares() {
@@ -28,8 +29,25 @@ export default function AdminCoursewares() {
     try {
       await shareCourseware(cid);
       alert('已共享');
+      load();
     } catch (err) {
       alert('操作失败');
+    }
+  };
+
+  const handleDownload = async (cid, topic) => {
+    try {
+      const blob = await downloadCourseware(cid);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `lesson_${topic}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert('下载失败');
     }
   };
 
@@ -59,9 +77,23 @@ export default function AdminCoursewares() {
                   <td>{c.teacher_id}</td>
                   <td>{c.created_at}</td>
                   <td>
-                    <button className="button" onClick={() => handleShare(c.id)}>
-                      共享
+                    <button
+                      className="button"
+                      onClick={() => handleShare(c.id)}
+                      disabled={c.topic.endsWith('-public')}
+                    >
+                      {c.topic.endsWith('-public') ? '已共享' : '共享'}
                     </button>
+                    <button
+                      className="button"
+                      style={{ marginTop: '0.5rem' }}
+                      onClick={() => handleDownload(c.id, c.topic)}
+                    >
+                      下载
+                    </button>
+                    <Link className="button" style={{ marginTop: '0.5rem', display: 'block' }} to={`/admin/courseware/${c.id}/edit`}>
+                      编辑
+                    </Link>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -35,6 +35,9 @@ export default function AdminDashboard() {
           <li>练习数量: {data.exercise_count}</li>
           <li>教师今日使用次数: {data.teacher_usage_today}</li>
           <li>学生今日使用次数: {data.student_usage_today}</li>
+          <li>教师本周使用次数: {data.teacher_usage_week}</li>
+          <li>学生本周使用次数: {data.student_usage_week}</li>
+          <li>教学效率指数(秒): {data.teaching_efficiency.toFixed ? data.teaching_efficiency.toFixed(2) : data.teaching_efficiency}</li>
         </ul>
       </div>
     </div>

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import AdminLayout from './AdminLayout';
 import AdminUsers from './AdminUsers';
 import AdminCoursewares from './AdminCoursewares';
+import AdminCoursewareEdit from './AdminCoursewareEdit';
 import AdminDashboard from './AdminDashboard';
 
 export default function AdminPage() {
@@ -11,6 +12,7 @@ export default function AdminPage() {
       <Route element={<AdminLayout />}>
         <Route path="users" element={<AdminUsers />} />
         <Route path="coursewares" element={<AdminCoursewares />} />
+        <Route path="courseware/:id/edit" element={<AdminCoursewareEdit />} />
         <Route path="dashboard" element={<AdminDashboard />} />
         <Route index element={<Navigate to="dashboard" replace />} />
         <Route path="*" element={<Navigate to="dashboard" replace />} />


### PR DESCRIPTION
## Summary
- track logins and prep times in backend models
- record login events on auth
- allow admin to preview, update and download courseware
- expose efficiency and login stats on dashboard
- disable public courseware sharing button
- add admin page to edit courseware

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(0 tests collected)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68728e22b1948322a3f22a868d941ac5