### PR TITLE
Improve exercise generator UI

### DIFF
--- a/frontend/src/components/Stepper.jsx
+++ b/frontend/src/components/Stepper.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+export default function Stepper({ value, onChange, min = 0, max = 50 }) {
+  const dec = () => onChange(Math.max(min, value - 1));
+  const inc = () => onChange(Math.min(max, value + 1));
+  const handleInput = (e) => {
+    let val = Number(e.target.value);
+    if (isNaN(val)) val = min;
+    if (val > max) val = max;
+    if (val < min) val = min;
+    onChange(val);
+  };
+  return (
+    <div className="stepper">
+      <button type="button" className="stepper-btn" onClick={dec} disabled={value <= min}>-
+      </button>
+      <input
+        type="number"
+        className="stepper-input"
+        value={value}
+        onChange={handleInput}
+        min={min}
+        max={max}
+      />
+      <button type="button" className="stepper-btn" onClick={inc} disabled={value >= max}>+
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/Tooltip.jsx
+++ b/frontend/src/components/Tooltip.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Tooltip({ text }) {
+  return (
+    <span className="tooltip">
+      <span className="tooltip-icon">?</span>
+      <span className="tooltip-text">{text}</span>
+    </span>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -233,3 +233,78 @@ td {
 .preview-column .actions {
   margin-top: 0;
 }
+
+/* Stepper component */
+.stepper {
+  display: flex;
+  align-items: center;
+}
+.stepper-btn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid #d2d2d7;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.stepper-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.stepper-input {
+  width: 60px;
+  text-align: center;
+  margin: 0 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 4px;
+}
+
+/* Tooltip */
+.tooltip {
+  position: relative;
+  display: inline-block;
+  margin-left: 0.25rem;
+}
+.tooltip-icon {
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  font-size: 12px;
+  background: #e0e0e0;
+  border-radius: 50%;
+  text-align: center;
+  cursor: pointer;
+}
+.tooltip-text {
+  visibility: hidden;
+  opacity: 0;
+  background: #333;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  position: absolute;
+  z-index: 10;
+  white-space: nowrap;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: opacity 0.2s;
+}
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Grid layout for question config */
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.total-count {
+  text-align: right;
+  margin-top: 1rem;
+  font-weight: bold;
+}

--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import Stepper from "../components/Stepper";
+import Tooltip from "../components/Tooltip";
 
 import {
   generateExerciseJson,
@@ -119,73 +121,80 @@ export default function ExercisePage() {
     }
   };
 
+  const total =
+    form.num_mcq +
+    form.num_fill_blank +
+    form.num_short_answer +
+    form.num_programming;
+
   return (
     <div className="container">
-      <div className="card">
-        <h2>练习题生成</h2>
-        {error && <div className="error">{error}</div>}
-        <form onSubmit={handleGenerate}>
-          <label>
-            主题
-            <input
-              className="input"
-              name="topic"
-              value={form.topic}
-              onChange={handleChange}
-              required
-            />
-          </label>
-          <label>
-            选择题数量
-            <input
-              className="input"
-              type="number"
-              name="num_mcq"
-              value={form.num_mcq}
-              onChange={handleChange}
-              min="0"
-            />
-          </label>
-          <label>
-            填空题数量
-            <input
-              className="input"
-              type="number"
-              name="num_fill_blank"
-              value={form.num_fill_blank}
-              onChange={handleChange}
-              min="0"
-            />
-          </label>
-          <label>
-            简答题数量
-            <input
-              className="input"
-              type="number"
-              name="num_short_answer"
-              value={form.num_short_answer}
-              onChange={handleChange}
-              min="0"
-            />
-          </label>
-          <label>
-            编程题数量
-            <input
-              className="input"
-              type="number"
-              name="num_programming"
-              value={form.num_programming}
-              onChange={handleChange}
-              min="0"
-            />
-          </label>
+      <form onSubmit={handleGenerate} style={{ width: "100%", maxWidth: "960px" }}>
+        <div className="card" style={{ marginBottom: "1rem" }}>
+          <h2>1. 输入主题</h2>
+          {error && <div className="error">{error}</div>}
+          <input
+            className="input"
+            name="topic"
+            value={form.topic}
+            onChange={handleChange}
+            required
+            placeholder="输入练习主题"
+          />
+        </div>
+        <div className="card">
+          <h2>2. 配置题量</h2>
+          <div className="grid-2">
+            <label>
+              选择题数量
+              <Tooltip text="单选或多选题目" />
+              <Stepper
+                value={form.num_mcq}
+                onChange={(v) => setForm((p) => ({ ...p, num_mcq: v }))}
+                min={0}
+                max={20}
+              />
+            </label>
+            <label>
+              填空题数量
+              <Tooltip text="在句子中留空填入答案" />
+              <Stepper
+                value={form.num_fill_blank}
+                onChange={(v) => setForm((p) => ({ ...p, num_fill_blank: v }))}
+                min={0}
+                max={20}
+              />
+            </label>
+            <label>
+              简答题数量
+              <Tooltip text="需要简短回答的题目" />
+              <Stepper
+                value={form.num_short_answer}
+                onChange={(v) => setForm((p) => ({ ...p, num_short_answer: v }))}
+                min={0}
+                max={20}
+              />
+            </label>
+            <label>
+              编程题数量
+              <Tooltip text="提交代码的题目" />
+              <Stepper
+                value={form.num_programming}
+                onChange={(v) => setForm((p) => ({ ...p, num_programming: v }))}
+                min={0}
+                max={20}
+              />
+            </label>
+          </div>
+          <div className="total-count">共计 {total} 题</div>
           <button className="button" type="submit" disabled={loading}>
             {loading ? "生成中…" : "生成练习"}
           </button>
-        </form>
+        </div>
+      </form>
 
         {preview && (
-          <>
+          <div className="card" style={{ marginTop: "1rem" }}>
             <div className="actions">
               <button className="button" onClick={handleSave} disabled={saved}>
                 {saved ? "已保存" : "保存练习"}
@@ -219,9 +228,8 @@ export default function ExercisePage() {
                 </div>
               ))}
             </div>
-          </>
+          </div>
         )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create Stepper and Tooltip components
- redesign ExercisePage with topic and question amount cards
- add totals and stepper controls with tooltips
- style updates for stepper, tooltip and grid layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68749db6ac708322b759e286a081d8df