### PR TITLE
Update exercise preview layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -308,3 +308,13 @@ td {
   margin-top: 1rem;
   font-weight: bold;
 }
+
+/* Preview area below generate button */
+.preview-area {
+  width: 100%;
+  margin-top: 1rem;
+  padding: 1rem;
+  background: #f9f9f9;
+  border-radius: 8px;
+  overflow-x: auto;
+}

--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -20,6 +20,7 @@ export default function ExercisePage() {
     num_programming: 0,
   });
   const [preview, setPreview] = useState(null);
+  const [showPreview, setShowPreview] = useState(false);
   const [exId, setExId] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -44,6 +45,7 @@ export default function ExercisePage() {
     try {
       const data = await generateExerciseJson(form);
       setPreview(data);
+      setShowPreview(true);
     } catch (err) {
       console.error(err);
       setError(err.response?.data?.detail || "生成练习失败");
@@ -193,8 +195,8 @@ export default function ExercisePage() {
         </div>
       </form>
 
-        {preview && (
-          <div className="card" style={{ marginTop: "1rem" }}>
+        {showPreview && preview && (
+          <div className="preview-area card" style={{ marginTop: "1rem" }}>
             <div className="actions">
               <button className="button" onClick={handleSave} disabled={saved}>
                 {saved ? "已保存" : "保存练习"}


### PR DESCRIPTION
## Summary
- show exercise preview below the form instead of in a side drawer
- style new preview-area container

## Testing
- `npm run lint` *(fails: 'err' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6874a25ba5e08322913092a412e9ba0c