### PR TITLE
Fix preview layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,10 +10,12 @@ html, body, #root {
 
 .container {
   display: flex;
+  flex-direction: column; /* stack children vertically */
   justify-content: center;
   align-items: center;
   min-height: 100%;
   padding: 2rem;
+  gap: 1rem; /* space between stacked elements */
 }
 
 .card {


### PR DESCRIPTION
## Summary
- adjust `.container` flex-direction to stack children vertically so the exercise preview appears below the generation form

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm --prefix frontend run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6874a49a48ac83228a7ab948866ee277