### PR TITLE
Update student homework list

### DIFF
--- a/backend/schemas/submission_schema.py
+++ b/backend/schemas/submission_schema.py
@@ -21,6 +21,7 @@ class HomeworkStudentOut(BaseModel):
     assigned_at: datetime
     status: str                    # "not_submitted"/"grading"/"completed"
     submission_id: Optional[int]
+    subject: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/backend/services/submission_service.py
+++ b/backend/services/submission_service.py
@@ -72,19 +72,25 @@ def list_student_homeworks(student_id: int) -> List[Dict[str, Any]]:
         for hw in hws:
             sub = sess.exec(
                 select(Submission)
-                .where(Submission.homework_id == hw.id,
-                       Submission.student_id == student_id)
+                .where(
+                    Submission.homework_id == hw.id,
+                    Submission.student_id == student_id,
+                )
             ).first()
             if not sub:
                 status, sid = "not_submitted", None
             else:
                 status, sid = sub.status, sub.id
+
+            ex = sess.get(Exercise, hw.exercise_id)
+
             out.append({
-                "homework_id":   hw.id,
-                "exercise_id":   hw.exercise_id,
-                "assigned_at":   hw.assigned_at,
-                "status":        status,
-                "submission_id": sid
+                "homework_id": hw.id,
+                "exercise_id": hw.exercise_id,
+                "assigned_at": hw.assigned_at,
+                "status": status,
+                "submission_id": sid,
+                "subject": ex.subject if ex else None,
             })
     return out
 

--- a/frontend/src/pages/StudentHomeworks.jsx
+++ b/frontend/src/pages/StudentHomeworks.jsx
@@ -7,6 +7,12 @@ export default function StudentHomeworks() {
   const navigate = useNavigate();
   const [list, setList] = useState([]);
 
+  const statusMap = {
+    not_submitted: "未提交",
+    grading: "批改中",
+    completed: "已完成",
+  };
+
   useEffect(() => {
     const load = async () => {
       try {
@@ -26,7 +32,7 @@ export default function StudentHomeworks() {
         <table>
           <thead>
             <tr>
-              <th>ID</th>
+              <th>标题</th>
               <th>状态</th>
               <th>操作</th>
             </tr>
@@ -34,8 +40,8 @@ export default function StudentHomeworks() {
           <tbody>
             {list.map((hw) => (
               <tr key={hw.homework_id}>
-                <td>{hw.homework_id}</td>
-                <td>{hw.status}</td>
+                <td>{hw.subject}</td>
+                <td>{statusMap[hw.status] || hw.status}</td>
                 <td>
                   {hw.status === "not_submitted" && (
                     <button


### PR DESCRIPTION
## Summary
- add exercise subject to homework list API
- output subject field in `HomeworkStudentOut`
- localize status text and show title in student homework list

## Testing
- `npm --prefix frontend run lint` *(fails: 9 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a85cca308322a19be394362dba08