### PR TITLE
Improve homework result UI

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -351,3 +351,87 @@ table tr:nth-child(even) {
 .badge-grading {
   background-color: #df5ae3;
 }
+
+/* ----- Homework result styles ----- */
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-card {
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.section-header {
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+}
+
+.header-multiple_choice {
+  background: #e0f2ff;
+}
+
+.header-fill_in_the_blank {
+  background: #ecfdf5;
+}
+
+.header-short_answer {
+  background: #fff7ed;
+}
+
+.section-content {
+  background: #ffffff;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.qbtn {
+  position: relative;
+  width: 2.5rem;
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid #E2E8F0;
+  background: #f8fafc;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.qbtn:hover {
+  background: #eef2f8;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.result-badge {
+  position: absolute;
+  top: -0.4rem;
+  right: -0.4rem;
+  padding: 0 0.25rem;
+  border-radius: 999px;
+  color: #fff;
+  font-size: 0.75rem;
+}
+
+.result-correct {
+  background: #22c55e;
+}
+
+.result-wrong {
+  background: #ef4444;
+}
+
+.score-badge {
+  align-self: center;
+  margin-left: 0.25rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background: #fb923c;
+  color: #fff;
+  font-size: 0.75rem;
+}

--- a/frontend/src/pages/StudentHomeworkResult.jsx
+++ b/frontend/src/pages/StudentHomeworkResult.jsx
@@ -33,9 +33,15 @@ export default function StudentHomeworkResult() {
   const fmt = (r) =>
     r === "correct" || r === "正确" || r === true ? "对" : "错";
 
+  const typeNames = {
+    multiple_choice: "选择题",
+    fill_in_the_blank: "填空题",
+    short_answer: "简答题",
+  };
+
   const questions = [];
   exercise.prompt.forEach((block) => {
-    block.items.forEach((item) => questions.push(item));
+    block.items.forEach((item) => questions.push({ ...item, type: block.type }));
   });
 
   const activeItem = questions.find((q) => String(q.id) === String(activeId));
@@ -43,26 +49,41 @@ export default function StudentHomeworkResult() {
   return (
     <div className="container">
       <div className="card">
-        <button
-          className="button"
-          style={{ width: "auto", marginBottom: "1rem" }}
-          onClick={() => navigate(-1)}
-        >
-          返回
-        </button>
-        <h2>作业结果</h2>
-        <div>总分：{score}</div>
-        <div className="actions">
-          {questions.map((q) => (
-            <button
-              key={q.id}
-              className="button"
-              onClick={() => setActiveId(q.id)}
-            >
-              {q.id}
-            </button>
-          ))}
+        <div className="result-header">
+          <button className="button" style={{ width: "auto" }} onClick={() => navigate(-1)}>
+            返回
+          </button>
+          <h2 style={{ margin: 0 }}>作业结果</h2>
+          <div>总分：{score}</div>
         </div>
+
+        {exercise.prompt.map((block, bIdx) => (
+          <div className="section-card" key={bIdx}>
+            <div className={`section-header header-${block.type}`}>
+              {typeNames[block.type] || block.type}（{block.items.length}/{block.items.length}）
+            </div>
+            <div className="section-content">
+              {block.items.map((item) => (
+                <div key={item.id} style={{ display: "flex" }}>
+                  <button className="qbtn" onClick={() => setActiveId(item.id)}>
+                    {item.id}
+                    <span
+                      className={`result-badge ${fmt(results[item.id]) === "对" ? "result-correct" : "result-wrong"}`}
+                    >
+                      {fmt(results[item.id]) === "对" ? "✔" : "✖"}
+                    </span>
+                  </button>
+                  {block.type === "short_answer" && (
+                    <span className="score-badge">
+                      {fmt(results[item.id]) === "对" ? 1 : 0}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+
         {activeItem && (
           <div style={{ marginTop: "1rem" }}>
             <h3>题号 {activeItem.id}</h3>


### PR DESCRIPTION
## Summary
- style page layout for student homework results
- group questions by type and show badges for correctness

## Testing
- `npm --prefix frontend run lint` *(fails: 'err' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_6874b30ca3e4832290772ea607e2db5a