### PR TITLE
Fix homework result display

### DIFF
--- a/backend/services/submission_service.py
+++ b/backend/services/submission_service.py
@@ -77,7 +77,7 @@ def list_student_homeworks(student_id: int) -> List[Dict[str, Any]]:
                     Submission.student_id == student_id,
                 )
             ).first()
-            if not sub:
+            if not sub or not sub.answers:
                 status, sid = "not_submitted", None
             else:
                 status, sid = sub.status, sub.id

--- a/frontend/src/pages/StudentHomeworkResult.jsx
+++ b/frontend/src/pages/StudentHomeworkResult.jsx
@@ -95,7 +95,12 @@ export default function StudentHomeworkResult() {
                 ))}
               </ul>
             )}
-            <div>我的答案：{String(student_answers[activeItem.id])}</div>
+            <div>
+              我的答案：
+              {student_answers[activeItem.id] !== undefined
+                ? String(student_answers[activeItem.id])
+                : "未作答"}
+            </div>
             <div>标准答案：{String(exercise.answers[activeItem.id])}</div>
             <div>结果：{fmt(results[activeItem.id])}</div>
             <div>解析：{feedback.explanations[activeItem.id]}</div>

--- a/frontend/src/pages/TeacherStudentHomeworkDetail.jsx
+++ b/frontend/src/pages/TeacherStudentHomeworkDetail.jsx
@@ -68,7 +68,12 @@ export default function TeacherStudentHomeworkDetail() {
                 ))}
               </ul>
             )}
-            <div>学生答案：{String(student_answers[activeItem.id])}</div>
+            <div>
+              学生答案：
+              {student_answers[activeItem.id] !== undefined
+                ? String(student_answers[activeItem.id])
+                : "未作答"}
+            </div>
             <div>标准答案：{String(exercise.answers[activeItem.id])}</div>
             <div>结果：{fmt(results[activeItem.id])}</div>
             <div>解析：{feedback.explanations[activeItem.id]}</div>


### PR DESCRIPTION
## Summary
- handle empty submission records when listing student homeworks
- display fallback text when student answer is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874cff94648832288fefaff5cfcea15