### PR TITLE
Fix class deletion bug and add leave feature

### DIFF
--- a/backend/routers/class_router.py
+++ b/backend/routers/class_router.py
@@ -150,3 +150,11 @@ def api_student_class_detail(cid: int, user: User = Depends(get_current_user)):
         ).one()
     return ClassOut(id=c.id, name=c.name, subject=c.subject, student_count=count)
 
+
+@router.delete("/student/{cid}")
+def api_student_leave_class(cid: int, user: User = Depends(get_current_user)):
+    if user.role.name != "student":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限学生访问")
+    remove_student_from_class(cid, user.id)
+    return {"status": "ok"}
+

--- a/backend/services/class_service.py
+++ b/backend/services/class_service.py
@@ -54,7 +54,4 @@ def remove_student_from_class(class_id: int, student_id: int) -> None:
         assoc = sess.get(ClassStudent, (class_id, student_id))
         if assoc:
             sess.delete(assoc)
-            user = sess.get(User, student_id)
-            if user:
-                sess.delete(user)
             sess.commit()

--- a/frontend/src/api/student.js
+++ b/frontend/src/api/student.js
@@ -47,3 +47,7 @@ export async function fetchStudentClass(cid) {
   const resp = await api.get(`/classes/student/${cid}`);
   return resp.data;
 }
+
+export async function leaveClass(cid) {
+  await api.delete(`/classes/student/${cid}`);
+}

--- a/frontend/src/pages/StudentClassDetailPage.jsx
+++ b/frontend/src/pages/StudentClassDetailPage.jsx
@@ -1,12 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { fetchStudentClass } from '../api/student';
+import { fetchStudentClass, leaveClass } from '../api/student';
 import '../index.css';
 
 export default function StudentClassDetailPage() {
   const { cid } = useParams();
   const navigate = useNavigate();
   const [info, setInfo] = useState(null);
+
+  const handleLeave = async () => {
+    if (!window.confirm('确认退出该班级吗？')) return;
+    try {
+      await leaveClass(cid);
+      navigate(-1);
+    } catch (err) {
+      alert('退出失败');
+    }
+  };
 
   useEffect(() => {
     fetchStudentClass(cid).then(setInfo).catch(() => setInfo(null));
@@ -23,9 +33,14 @@ export default function StudentClassDetailPage() {
   return (
     <div className="container">
       <div className="card">
-        <button className="button" style={{ width: 'auto', marginBottom: '1rem' }} onClick={() => navigate(-1)}>
-          返回
-        </button>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <button className="button" style={{ width: 'auto', marginBottom: '1rem' }} onClick={() => navigate(-1)}>
+            返回
+          </button>
+          <button className="button" style={{ width: 'auto', marginBottom: '1rem' }} onClick={handleLeave}>
+            退出班级
+          </button>
+        </div>
         <h2>{info.name}</h2>
         <p>班级ID: {info.id}</p>
         <p>学科: {info.subject}</p>


### PR DESCRIPTION
## Summary
- remove accidental user deletion when removing a student from class
- allow students to leave classes via new API endpoint
- expose `leaveClass` on frontend API and add a button in class detail page

## Testing
- `npm --prefix frontend run lint` *(fails: many existing lint errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f5be3f1083229192efd8421785c9