### PR TITLE
Add persistent homework analysis

### DIFF
--- a/backend/create_db.sql
+++ b/backend/create_db.sql
@@ -198,6 +198,20 @@ CREATE TABLE `practice` (
   CONSTRAINT `fk_practice_student` FOREIGN KEY (`student_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
+DROP TABLE IF EXISTS `student_analysis`;
+CREATE TABLE `student_analysis` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `student_id` INT NOT NULL,
+  `teacher_id` INT DEFAULT NULL,
+  `content` LONGTEXT NOT NULL,
+  `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  KEY `idx_sa_student` (`student_id`),
+  KEY `idx_sa_teacher` (`teacher_id`),
+  CONSTRAINT `fk_sa_student` FOREIGN KEY (`student_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_sa_teacher` FOREIGN KEY (`teacher_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
 -- ------------------------------------------------------
 -- Table structure for table `class`
 --   - A class belongs to exactly one teacher

--- a/backend/models.py
+++ b/backend/models.py
@@ -23,6 +23,8 @@ class User(SQLModel, table=True):
     practices: List["Practice"]  = Relationship(back_populates="student")
     teaching_classes: List["Class"] = Relationship(back_populates="teacher")
     class_memberships: List["ClassStudent"] = Relationship(back_populates="student")
+    analyses: List["StudentAnalysis"] = Relationship(back_populates="student", sa_relationship_kwargs={"primaryjoin": "User.id==StudentAnalysis.student_id"})
+    analyses_for_teacher: List["StudentAnalysis"] = Relationship(back_populates="teacher", sa_relationship_kwargs={"primaryjoin": "User.id==StudentAnalysis.teacher_id"})
 
 
 class Exercise(SQLModel, table=True):
@@ -151,6 +153,19 @@ class Practice(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
     student: "User" = Relationship(back_populates="practices")
+
+
+class StudentAnalysis(SQLModel, table=True):
+    __tablename__ = "student_analysis"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    student_id: int = Field(foreign_key="user.id", nullable=False)
+    teacher_id: Optional[int] = Field(default=None, foreign_key="user.id")
+    content: str = Field(sa_column=Column(Text(collation="utf8mb4_unicode_ci")))
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    student: "User" = Relationship()
+    teacher: Optional["User"] = Relationship()
 
 
 class LoginEvent(SQLModel, table=True):

--- a/backend/models.py
+++ b/backend/models.py
@@ -23,8 +23,14 @@ class User(SQLModel, table=True):
     practices: List["Practice"]  = Relationship(back_populates="student")
     teaching_classes: List["Class"] = Relationship(back_populates="teacher")
     class_memberships: List["ClassStudent"] = Relationship(back_populates="student")
-    analyses: List["StudentAnalysis"] = Relationship(back_populates="student", sa_relationship_kwargs={"primaryjoin": "User.id==StudentAnalysis.student_id"})
-    analyses_for_teacher: List["StudentAnalysis"] = Relationship(back_populates="teacher", sa_relationship_kwargs={"primaryjoin": "User.id==StudentAnalysis.teacher_id"})
+    analyses: List["StudentAnalysis"] = Relationship(
+        back_populates="student",
+        sa_relationship_kwargs={"foreign_keys": "StudentAnalysis.student_id"},
+    )
+    analyses_for_teacher: List["StudentAnalysis"] = Relationship(
+        back_populates="teacher",
+        sa_relationship_kwargs={"foreign_keys": "StudentAnalysis.teacher_id"},
+    )
 
 
 class Exercise(SQLModel, table=True):
@@ -164,8 +170,14 @@ class StudentAnalysis(SQLModel, table=True):
     content: str = Field(sa_column=Column(Text(collation="utf8mb4_unicode_ci")))
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    student: "User" = Relationship()
-    teacher: Optional["User"] = Relationship()
+    student: "User" = Relationship(
+        back_populates="analyses",
+        sa_relationship_kwargs={"foreign_keys": "StudentAnalysis.student_id"},
+    )
+    teacher: Optional["User"] = Relationship(
+        back_populates="analyses_for_teacher",
+        sa_relationship_kwargs={"foreign_keys": "StudentAnalysis.teacher_id"},
+    )
 
 
 class LoginEvent(SQLModel, table=True):

--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -129,10 +129,11 @@ def api_submit(pid: int, req: PracticeSubmitRequest, user: User = Depends(get_cu
     return PracticeOut(id=pr.id, topic=pr.topic, questions=pr.questions, answers=pr.answers, status=pr.status, feedback=pr.feedback, score=pr.score)
 
 
-from backend.services.analysis_service import analyze_student_homeworks
+from backend.services.analysis_service import get_latest_analysis
 
 router_analysis = APIRouter(prefix="/student", tags=["student-analysis"])
 
 @router_analysis.get("/analysis")
 def api_analysis(user: User = Depends(get_current_user)):
-    return analyze_student_homeworks(user.id)
+    content = get_latest_analysis(user.id)
+    return {"analysis": content or ""}

--- a/backend/routers/teacher_router.py
+++ b/backend/routers/teacher_router.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from backend.auth import get_current_user
 from backend.config import engine
 from backend.models import User
-from backend.services.analysis_service import analyze_student_homeworks
+from backend.services.analysis_service import get_latest_analysis
 from backend.services.submission_service import (
     list_completed_submissions,
     get_submission_by_hw_student,
@@ -46,7 +46,8 @@ def list_students(current: User = Depends(get_current_user)):
 def student_analysis(sid: int, current: User = Depends(get_current_user)):
     if not current.role or current.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
-    return analyze_student_homeworks(sid)
+    content = get_latest_analysis(sid, teacher_id=current.id)
+    return {"analysis": content or ""}
 
 @router.get("/{sid}/homeworks", response_model=List[SubmissionMeta])
 def student_homeworks(sid: int, current: User = Depends(get_current_user)):

--- a/frontend/src/api/student.js
+++ b/frontend/src/api/student.js
@@ -32,6 +32,11 @@ export async function downloadSelfPracticePdf(id) {
   return resp.data;
 }
 
+export async function fetchStudentAnalysis() {
+  const resp = await api.get("/student/analysis");
+  return resp.data;
+}
+
 // ------ Class APIs ------
 
 export async function fetchMyClasses() {

--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import api from "../api/api";
-import { generateSelfPractice } from "../api/student";
+import { generateSelfPractice, fetchStudentAnalysis } from "../api/student";
 import { useNavigate } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -26,8 +26,8 @@ export default function EvaluateAssistant() {
       setAnalysis("");
       setAnalysisLoading(true);
       try {
-        const resp = await api.get("/student/analysis");
-        setAnalysis(resp.data.analysis || JSON.stringify(resp.data));
+        const resp = await fetchStudentAnalysis();
+        setAnalysis(resp.analysis || "");
       } catch (err) {
         console.error(err);
         setError("加载分析失败");

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { getSelfPractice, downloadSelfPracticePdf } from "../api/student";
+import { getSelfPractice, downloadSelfPracticePdf, fetchStudentAnalysis } from "../api/student";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import "../index.css";
 
 export default function SelfPracticeDetail() {
@@ -9,6 +11,8 @@ export default function SelfPracticeDetail() {
   const [practice, setPractice] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [analysis, setAnalysis] = useState("");
+  const [analysisLoading, setAnalysisLoading] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -26,6 +30,21 @@ export default function SelfPracticeDetail() {
     };
     load();
   }, [id]);
+
+  useEffect(() => {
+    const load = async () => {
+      setAnalysisLoading(true);
+      try {
+        const data = await fetchStudentAnalysis();
+        setAnalysis(data.analysis);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setAnalysisLoading(false);
+      }
+    };
+    load();
+  }, []);
 
   const handleDownload = async () => {
     const blob = await downloadSelfPracticePdf(id);
@@ -50,6 +69,11 @@ export default function SelfPracticeDetail() {
           返回
         </button>
         <h2>随练预览</h2>
+        <div className="markdown-preview" style={{ minHeight: '4rem' }}>
+          {analysisLoading ? '正在分析...' : (
+            <ReactMarkdown children={analysis} remarkPlugins={[remarkGfm]} />
+          )}
+        </div>
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>


### PR DESCRIPTION
## Summary
- store student learning analysis in new `student_analysis` table
- compute and save analysis when grading submissions
- expose latest analysis via teacher and student endpoints
- display stored analysis in SelfPracticeDetail
- allow frontend to fetch analysis

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687624eec1e08322aa0185bb5572f6d1