### PR TITLE
Fix missing input box for fill-in and short answer

### DIFF
--- a/frontend/src/pages/StudentHomeworkAnswer.jsx
+++ b/frontend/src/pages/StudentHomeworkAnswer.jsx
@@ -75,7 +75,7 @@ export default function StudentHomeworkAnswer() {
   };
 
   const renderInput = () => {
-    if (question.options) return renderOptions();
+    if (question.options && question.options.length > 0) return renderOptions();
     return (
       <textarea
         className="input"


### PR DESCRIPTION
## Summary
- fix condition that determined when to display textarea so that fill-in-the-blank and short answer questions render correctly

## Testing
- `npm run lint` *(fails: no-unused-vars in unrelated files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68762cc7da6483228bae69b7f0b1dbf7