### PR TITLE
Filter teacher analysis by class

### DIFF
--- a/backend/routers/teacher_router.py
+++ b/backend/routers/teacher_router.py
@@ -7,8 +7,8 @@ from pydantic import BaseModel
 
 from backend.auth import get_current_user
 from backend.config import engine
-from backend.models import User
-from backend.services.analysis_service import get_latest_analysis
+from backend.models import User, Class
+from backend.services.analysis_service import get_latest_analysis, analyze_student_homeworks
 from backend.services.submission_service import (
     list_completed_submissions,
     get_submission_by_hw_student,
@@ -43,9 +43,21 @@ def list_students(current: User = Depends(get_current_user)):
         return [StudentMeta.model_validate(u, from_attributes=True) for u in users]
 
 @router.get("/{sid}/analysis")
-def student_analysis(sid: int, current: User = Depends(get_current_user)):
+def student_analysis(
+    sid: int,
+    class_id: int | None = None,
+    current: User = Depends(get_current_user),
+):
     if not current.role or current.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
+
+    if class_id is not None:
+        with Session(engine) as sess:
+            c = sess.get(Class, class_id)
+            if not c or c.teacher_id != current.id:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="class not found")
+        return analyze_student_homeworks(sid, teacher_id=current.id, class_id=class_id)
+
     content = get_latest_analysis(sid, teacher_id=current.id)
     return {"analysis": content or ""}
 

--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -227,8 +227,11 @@ export async function fetchStudentList() {
 }
 
 /** 获取学生学情分析 */
-export async function fetchStudentAnalysis(sid) {
-  const resp = await api.get(`/teacher/students/${sid}/analysis`);
+export async function fetchStudentAnalysis(sid, classId) {
+  const url = classId
+    ? `/teacher/students/${sid}/analysis?class_id=${classId}`
+    : `/teacher/students/${sid}/analysis`;
+  const resp = await api.get(url);
   return resp.data;
 }
 

--- a/frontend/src/pages/TeacherClassDetailPage.jsx
+++ b/frontend/src/pages/TeacherClassDetailPage.jsx
@@ -79,6 +79,13 @@ export default function TeacherClassDetailPage() {
                 <td>{s.id}</td>
                 <td>{s.username}</td>
                 <td>
+                  <button
+                    className="button"
+                    style={{ width: 'auto', marginRight: '0.5rem' }}
+                    onClick={() => navigate(`/teacher/students/${s.id}?cid=${cid}`)}
+                  >
+                    查看学情
+                  </button>
                   <button className="button" style={{ width: 'auto' }} onClick={() => handleRemove(s.id)}>
                     删除
                   </button>

--- a/frontend/src/pages/TeacherStudentDetail.jsx
+++ b/frontend/src/pages/TeacherStudentDetail.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { fetchStudentAnalysis, fetchStudentHomeworks } from '../api/teacher';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -8,6 +8,8 @@ import '../index.css';
 export default function TeacherStudentDetail() {
   const { sid } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const cid = searchParams.get('cid');
   const [analysis, setAnalysis] = useState('');
   const [homeworks, setHomeworks] = useState([]);
   const [loadingHw, setLoadingHw] = useState(false);
@@ -17,7 +19,7 @@ export default function TeacherStudentDetail() {
   useEffect(() => {
     setAnalysis('');
     setAnalysisLoading(true);
-    fetchStudentAnalysis(sid)
+    fetchStudentAnalysis(sid, cid)
       .then((a) => setAnalysis(a.analysis))
       .catch((err) => {
         console.error(err);
@@ -33,7 +35,7 @@ export default function TeacherStudentDetail() {
         setError('加载失败');
       })
       .finally(() => setLoadingHw(false));
-  }, [sid]);
+  }, [sid, cid]);
 
   return (
     <div className="container">


### PR DESCRIPTION
## Summary
- restrict teacher-side student analysis to a specific class
- adjust analysis service to filter homework by class
- expose optional `class_id` query for teacher student analysis API
- update frontend APIs and pages to pass class id
- add link from teacher class page to view student progress

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68762fa936a48322981dbbe6295e7316