### PR TITLE
Fix navigation and homework filtering

### DIFF
--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -236,8 +236,11 @@ export async function fetchStudentAnalysis(sid, classId) {
 }
 
 /** 获取学生已完成练习列表 */
-export async function fetchStudentHomeworks(sid) {
-  const resp = await api.get(`/teacher/students/${sid}/homeworks`);
+export async function fetchStudentHomeworks(sid, classId) {
+  const url = classId
+    ? `/teacher/students/${sid}/homeworks?class_id=${classId}`
+    : `/teacher/students/${sid}/homeworks`;
+  const resp = await api.get(url);
   return resp.data;
 }
 

--- a/frontend/src/pages/TeacherLayout.jsx
+++ b/frontend/src/pages/TeacherLayout.jsx
@@ -35,7 +35,6 @@ export default function TeacherLayout() {
         <button className="button" onClick={() => nav("/teacher/exercise")}>练习生成</button>
         <button className="button" onClick={() => nav("/teacher/exercise/list")}>练习列表</button>
         <button className="button" onClick={() => nav("/teacher/classes")}>班级管理</button>
-        <button className="button" onClick={() => nav("/teacher/students")}>学情数据</button>
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>
       </div>

--- a/frontend/src/pages/TeacherStudentDetail.jsx
+++ b/frontend/src/pages/TeacherStudentDetail.jsx
@@ -28,7 +28,7 @@ export default function TeacherStudentDetail() {
       .finally(() => setAnalysisLoading(false));
 
     setLoadingHw(true);
-    fetchStudentHomeworks(sid)
+    fetchStudentHomeworks(sid, cid)
       .then((list) => setHomeworks(list))
       .catch((err) => {
         console.error(err);


### PR DESCRIPTION
## Summary
- remove `学情数据` from teacher sidebar
- pass class ID when fetching student data on the teacher side
- allow filtering homeworks by teacher/class in the backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and numerous lint errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68763c2079cc8322bab84aa9fde8b8cc