### PR TITLE
Fix teacher student analysis navigation and class filtering

### DIFF
--- a/backend/routers/teacher_router.py
+++ b/backend/routers/teacher_router.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from backend.auth import get_current_user
 from backend.config import engine
 from backend.models import User, Class
-from backend.services.analysis_service import get_latest_analysis, analyze_student_homeworks
+from backend.services.analysis_service import get_latest_analysis
 from backend.services.submission_service import (
     list_completed_submissions,
     get_submission_by_hw_student,
@@ -56,16 +56,24 @@ def student_analysis(
             c = sess.get(Class, class_id)
             if not c or c.teacher_id != current.id:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="class not found")
-        return analyze_student_homeworks(sid, teacher_id=current.id, class_id=class_id)
 
     content = get_latest_analysis(sid, teacher_id=current.id)
     return {"analysis": content or ""}
 
 @router.get("/{sid}/homeworks", response_model=List[SubmissionMeta])
-def student_homeworks(sid: int, current: User = Depends(get_current_user)):
+def student_homeworks(
+    sid: int,
+    class_id: int | None = None,
+    current: User = Depends(get_current_user),
+):
     if not current.role or current.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
-    subs = list_completed_submissions(sid)
+    if class_id is not None:
+        with Session(engine) as sess:
+            c = sess.get(Class, class_id)
+            if not c or c.teacher_id != current.id:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="class not found")
+    subs = list_completed_submissions(sid, class_id=class_id)
     return [
         SubmissionMeta(
             homework_id=s.homework_id,

--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -236,8 +236,11 @@ export async function fetchStudentAnalysis(sid, classId) {
 }
 
 /** 获取学生已完成练习列表 */
-export async function fetchStudentHomeworks(sid) {
-  const resp = await api.get(`/teacher/students/${sid}/homeworks`);
+export async function fetchStudentHomeworks(sid, classId) {
+  const url = classId
+    ? `/teacher/students/${sid}/homeworks?class_id=${classId}`
+    : `/teacher/students/${sid}/homeworks`;
+  const resp = await api.get(url);
   return resp.data;
 }
 

--- a/frontend/src/pages/TeacherLayout.jsx
+++ b/frontend/src/pages/TeacherLayout.jsx
@@ -35,7 +35,6 @@ export default function TeacherLayout() {
         <button className="button" onClick={() => nav("/teacher/exercise")}>练习生成</button>
         <button className="button" onClick={() => nav("/teacher/exercise/list")}>练习列表</button>
         <button className="button" onClick={() => nav("/teacher/classes")}>班级管理</button>
-        <button className="button" onClick={() => nav("/teacher/students")}>学情数据</button>
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>
       </div>

--- a/frontend/src/pages/TeacherStudentDetail.jsx
+++ b/frontend/src/pages/TeacherStudentDetail.jsx
@@ -28,7 +28,7 @@ export default function TeacherStudentDetail() {
       .finally(() => setAnalysisLoading(false));
 
     setLoadingHw(true);
-    fetchStudentHomeworks(sid)
+    fetchStudentHomeworks(sid, cid)
       .then((list) => setHomeworks(list))
       .catch((err) => {
         console.error(err);


### PR DESCRIPTION
## Summary
- avoid calling large model when teacher views student analysis
- filter completed submissions by class id
- adjust API and UI to pass class id
- remove student analysis button from teacher sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876400532c88322a43563decb101078