### PR TITLE
Add admin public doc management and fix doc retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ backend/.env
 
 .idea/
 .vscode/
+/backend/storage

--- a/backend/utils/rag_pipeline.py
+++ b/backend/utils/rag_pipeline.py
@@ -172,7 +172,8 @@ def retrieve_from_db(query: str, user_id: int, session, top_k: int = 5) -> List[
         "WHERE ((d.owner_id=:uid AND d.is_active=1) "
         "OR (d.is_public=1 AND d.is_active=1))"
     )
-    rows = session.exec(text(sql), {"uid": user_id}).all()
+    stmt = text(sql).bindparams(uid=user_id)
+    rows = session.exec(stmt).all()
     if not rows:
         return []
     vectors = [np.frombuffer(r.vector_blob, dtype=np.float32) for r in rows]

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -44,3 +44,20 @@ export async function fetchDashboard() {
   const resp = await api.get('/admin/dashboard');
   return resp.data;
 }
+
+// ----- Public document management -----
+export async function uploadPublicDoc(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const resp = await api.post('/admin/public_docs', form);
+  return resp.data;
+}
+
+export async function fetchPublicDocs() {
+  const resp = await api.get('/admin/public_docs');
+  return resp.data;
+}
+
+export async function deletePublicDoc(id) {
+  await api.delete(`/admin/public_docs/${id}`);
+}

--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -32,6 +32,7 @@ export default function AdminLayout() {
         <div style={{ marginBottom: '1rem' }}>您好，管理员{username}</div>
         <button className="button" onClick={() => nav('/admin/users')}>用户管理</button>
         <button className="button" onClick={() => nav('/admin/coursewares')}>课件管理</button>
+        <button className="button" onClick={() => nav('/admin/public_docs')}>公共课件管理</button>
         <button className="button" onClick={() => nav('/admin/dashboard')}>数据概览</button>
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -5,6 +5,7 @@ import AdminUsers from './AdminUsers';
 import AdminCoursewares from './AdminCoursewares';
 import AdminCoursewareEdit from './AdminCoursewareEdit';
 import AdminDashboard from './AdminDashboard';
+import AdminPublicDocs from './AdminPublicDocs';
 
 export default function AdminPage() {
   return (
@@ -13,6 +14,7 @@ export default function AdminPage() {
         <Route path="users" element={<AdminUsers />} />
         <Route path="coursewares" element={<AdminCoursewares />} />
         <Route path="courseware/:id/edit" element={<AdminCoursewareEdit />} />
+        <Route path="public_docs" element={<AdminPublicDocs />} />
         <Route path="dashboard" element={<AdminDashboard />} />
         <Route index element={<Navigate to="dashboard" replace />} />
         <Route path="*" element={<Navigate to="dashboard" replace />} />

--- a/frontend/src/pages/AdminPublicDocs.jsx
+++ b/frontend/src/pages/AdminPublicDocs.jsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import {
+  uploadPublicDoc,
+  fetchPublicDocs,
+  deletePublicDoc,
+} from '../api/admin';
+import '../index.css';
+
+export default function AdminPublicDocs() {
+  const [list, setList] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchPublicDocs();
+      setList(data);
+    } catch (err) {
+      setError('加载失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleUpload = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    try {
+      await uploadPublicDoc(file);
+      load();
+    } catch (err) {
+      alert('上传失败');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('确定删除?')) return;
+    try {
+      await deletePublicDoc(id);
+      load();
+    } catch (err) {
+      alert('删除失败');
+    }
+  };
+
+  return (
+    <div className="container">
+      <div className="card">
+        <h2>公共课件管理</h2>
+        <div style={{ marginBottom: '1rem' }}>
+          <input type="file" onChange={handleUpload} />
+        </div>
+        {error && <div className="error">{error}</div>}
+        {loading ? (
+          <div>加载中...</div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>文件名</th>
+                <th>上传时间</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map((d) => (
+                <tr key={d.id}>
+                  <td>{d.filename}</td>
+                  <td>{d.uploaded_at}</td>
+                  <td>
+                    <button className="button" onClick={() => handleDelete(d.id)}>删除</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fix `retrieve_from_db` query parameter binding to avoid `Session.exec` error
- implement `save_public_document` and `delete_public_document` service helpers
- expose public document management endpoints in `admin_router`
- extend admin JS API and UI to manage public docs
- add Public Docs page and menu item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877725b3a04832296959d0863bd737d