### PR TITLE
Fix document listing and activation

### DIFF
--- a/backend/routers/doc_router.py
+++ b/backend/routers/doc_router.py
@@ -68,7 +68,9 @@ from fastapi import Body
 
 @router.patch("/{doc_id}/activate")
 def activate_doc(
-    doc_id: int, is_active: bool = Body(...), current: User = Depends(get_current_user)
+    doc_id: int,
+    is_active: bool = Body(..., embed=True),
+    current: User = Depends(get_current_user),
 ):
     if current.role.name != "teacher":
         raise HTTPException(

--- a/backend/services/document_service.py
+++ b/backend/services/document_service.py
@@ -86,17 +86,17 @@ def list_my_documents(owner_id: int) -> List[Document]:
     with Session(engine) as sess:
         stmt = (
             select(Document, DocumentActivation.is_active)
-            .join(DocumentActivation, DocumentActivation.doc_id == Document.id)
-            .where(
-                Document.owner_id == owner_id,
-                DocumentActivation.teacher_id == owner_id,
-                DocumentActivation.is_active == True,
+            .outerjoin(
+                DocumentActivation,
+                (DocumentActivation.doc_id == Document.id)
+                & (DocumentActivation.teacher_id == owner_id),
             )
+            .where(Document.owner_id == owner_id)
         )
         rows = sess.exec(stmt).all()
         docs: List[Document] = []
         for doc, active in rows:
-            doc.is_active = active
+            doc.is_active = bool(active) if active is not None else False
             docs.append(doc)
         return docs
 


### PR DESCRIPTION
## Summary
- show all teacher documents, not only active ones, so newly uploaded files appear
- compute activation state correctly when listing

## Testing
- `python -m py_compile backend/services/document_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6877915f0ae08322b17e0edf06ca3982