### PR TITLE
Improve document management page

### DIFF
--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -281,11 +281,17 @@ export async function deleteClass(cid) {
 }
 
 // ----- Document management -----
-export async function uploadDocument(file, isPublic = false) {
+export async function uploadDocument(file, isPublic = false, onProgress) {
   const form = new FormData();
   form.append('file', file);
   form.append('is_public', isPublic);
-  const resp = await api.post('/docs/', form);
+  const resp = await api.post('/docs/', form, {
+    onUploadProgress: (e) => {
+      if (!onProgress || !e.total) return;
+      const percent = Math.round((e.loaded * 100) / e.total);
+      onProgress(percent);
+    },
+  });
   return resp.data;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,8 +41,8 @@ html, body, #root {
 
 
 .card h2 {
-  margin: 0 0 1.5rem;
-  font-size: 2rem;
+  margin: 2rem 0 1.5rem;
+  font-size: 2.5rem;
   text-align: center;
   color: #334155;
 }
@@ -83,6 +83,11 @@ html, body, #root {
 .button:not(:disabled):hover {
   transform: scale(1.03);
   filter: brightness(1.1);
+}
+
+.button:focus {
+  outline: 2px solid #09adb9;
+  outline-offset: 2px;
 }
 
 .actions {
@@ -140,7 +145,8 @@ table, th, td {
 
 th {
   text-align: left;
-  background-color: #E6FFFA;
+  background-color: #f0f0f0;
+  font-weight: bold;
 }
 
 td {
@@ -148,7 +154,11 @@ td {
 }
 
 table tr:nth-child(even) {
-  background-color: #F0F9F9;
+  background-color: #fafafa;
+}
+
+table tr:hover {
+  background-color: #f0f0f0;
 }
 
 /* Small icon button used for history delete actions */
@@ -443,4 +453,129 @@ table tr:nth-child(even) {
   background: #fb923c;
   color: #fff;
   font-size: 0.75rem;
+}
+
+/* ---------- Tabs ---------- */
+.tab-container {
+  margin-bottom: 1rem;
+}
+
+.tabs {
+  display: flex;
+  gap: 1rem;
+  border-bottom: 1px solid #E2E8F0;
+  margin-bottom: 0.5rem;
+}
+
+.tab {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: #334155;
+  font-size: 1rem;
+}
+
+.tab:hover {
+  background-color: #f0f0f0;
+}
+
+.tab.active {
+  border-bottom-color: #09adb9;
+  font-weight: bold;
+  color: #09adb9;
+}
+
+.tab:focus {
+  outline: 2px solid #09adb9;
+  outline-offset: 2px;
+}
+
+.tab-select {
+  display: none;
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #E2E8F0;
+  border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+  .tabs {
+    display: none;
+  }
+  .tab-select {
+    display: block;
+  }
+}
+
+/* ---------- Upload dropzone ---------- */
+.upload-dropzone {
+  border: 2px dashed #E2E8F0;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 8px;
+  cursor: pointer;
+  background: #fafafa;
+}
+
+.upload-dropzone:hover {
+  background: #f0f0f0;
+}
+
+.upload-icon {
+  font-size: 2rem;
+  color: #09adb9;
+}
+
+.progress {
+  width: 100%;
+  height: 8px;
+  background: #e5e5e5;
+  border-radius: 4px;
+  margin-top: 0.5rem;
+}
+
+.progress-bar {
+  height: 100%;
+  background: #09adb9;
+  border-radius: 4px;
+}
+
+.progress-text {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+}
+
+/* ---------- Tags ---------- */
+.tag {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  color: #fff;
+  font-size: 0.875rem;
+}
+
+.tag-green {
+  background-color: #22c55e;
+}
+
+.tag-gray {
+  background-color: #6b7280;
+}
+
+.tag:focus {
+  outline: 2px solid #09adb9;
+  outline-offset: 2px;
+}
+
+/* ---------- Actions cell ---------- */
+.actions-cell {
+  white-space: nowrap;
+}
+
+.icon-button:focus {
+  outline: 2px solid #09adb9;
+  outline-offset: 2px;
 }

--- a/frontend/src/pages/DocumentManage.jsx
+++ b/frontend/src/pages/DocumentManage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   uploadDocument,
   fetchMyDocuments,
@@ -13,6 +13,9 @@ export default function DocumentManage() {
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const fileRef = useRef(null);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
 
   const load = async (scope) => {
     setLoading(true);
@@ -31,15 +34,32 @@ export default function DocumentManage() {
     load(tab);
   }, [tab]);
 
-  const handleUpload = async (e) => {
-    const file = e.target.files[0];
+  const handleFiles = async (files) => {
+    const file = files[0];
     if (!file) return;
     try {
-      await uploadDocument(file, false);
+      setUploading(true);
+      await uploadDocument(file, false, setProgress);
+      setUploading(false);
+      setProgress(0);
       load('my');
     } catch (err) {
       alert('上传失败');
+      setUploading(false);
     }
+  };
+
+  const openFileDialog = () => {
+    fileRef.current && fileRef.current.click();
+  };
+
+  const handleInputChange = (e) => {
+    handleFiles(e.target.files);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
   };
 
   const handleActivate = async (id, active) => {
@@ -61,13 +81,41 @@ export default function DocumentManage() {
     <div className="container">
       <div className="card">
         <h2>资料管理</h2>
-        <div style={{ marginBottom: '1rem' }}>
-          <button className="button" style={{ width: 'auto', marginRight: '1rem' }} onClick={() => setTab('my')}>我的私有资料</button>
-          <button className="button" style={{ width: 'auto' }} onClick={() => setTab('public')}>公共资料</button>
+        <div className="tab-container">
+          <div className="tabs">
+            <button
+              className={`tab ${tab === 'my' ? 'active' : ''}`}
+              onClick={() => setTab('my')}
+            >
+              我的私有资料
+            </button>
+            <button
+              className={`tab ${tab === 'public' ? 'active' : ''}`}
+              onClick={() => setTab('public')}
+            >
+              公共资料
+            </button>
+          </div>
+          <select
+            className="tab-select"
+            value={tab}
+            onChange={(e) => setTab(e.target.value)}
+          >
+            <option value="my">我的私有资料</option>
+            <option value="public">公共资料</option>
+          </select>
         </div>
         {tab === 'my' && (
-          <div style={{ marginBottom: '1rem' }}>
-            <input type="file" onChange={handleUpload} />
+          <div className="upload-dropzone" onDrop={handleDrop} onDragOver={(e) => e.preventDefault()} onClick={openFileDialog} role="button" tabIndex={0} onKeyDown={(e) => { if (e.key === 'Enter') openFileDialog(); }}>
+            <input type="file" ref={fileRef} onChange={handleInputChange} style={{ display: 'none' }} />
+            <div className="upload-icon">⬆️</div>
+            <p>拖拽文件到此处或点击上传</p>
+            {uploading && (
+              <div className="progress">
+                <div className="progress-bar" style={{ width: `${progress}%` }} />
+              </div>
+            )}
+            {uploading && <span className="progress-text">{progress}%</span>}
           </div>
         )}
         {error && <div className="error">{error}</div>}
@@ -88,14 +136,27 @@ export default function DocumentManage() {
                 <tr key={d.id}>
                   <td>{d.filename}</td>
                   <td>{d.uploaded_at}</td>
-                  <td>{d.is_active ? '已激活' : '未激活'}</td>
                   <td>
-                    <button className="button" style={{ width: 'auto' }} onClick={() => handleActivate(d.id, !d.is_active)}>
-                      {d.is_active ? '取消激活' : '激活'}
+                    <span className={`tag ${d.is_active ? 'tag-green' : 'tag-gray'}`}>{d.is_active ? '已激活' : '未激活'}</span>
+                  </td>
+                  <td className="actions-cell">
+                    <button
+                      className="icon-button tooltip"
+                      onClick={() => handleActivate(d.id, !d.is_active)}
+                      aria-label={d.is_active ? '取消激活' : '激活'}
+                    >
+                      {d.is_active ? '🛑' : '✅'}
+                      <span className="tooltip-text">{d.is_active ? '取消激活' : '激活'}</span>
                     </button>
                     {tab === 'my' && (
-                      <button className="button" style={{ width: 'auto', marginLeft: '0.5rem' }} onClick={() => handleDelete(d.id)}>
-                        删除
+                      <button
+                        className="icon-button tooltip"
+                        onClick={() => handleDelete(d.id)}
+                        aria-label="删除"
+                        style={{ marginLeft: '0.25rem' }}
+                      >
+                        🗑️
+                        <span className="tooltip-text">删除</span>
                       </button>
                     )}
                   </td>


### PR DESCRIPTION
## Summary
- add progress to uploadDocument API
- overhaul DocumentManage tabs and file upload UI
- restyle tables, buttons, and add new tab/dropzone styles
- enlarge card heading

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877c17978dc83229c854a461f722895