### PR TITLE
Improve sidebar toggle and adjust layouts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1688,6 +1688,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5160,21 +5161,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -215,13 +215,20 @@ table tr:hover {
 
 .toggle-btn {
   position: fixed;
-  top: 1rem;
-  left: 1rem;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  padding: 0.25rem 0.5rem;
+  background: #09adb9;
+  color: #fff;
+  border: none;
+  border-radius: 0 4px 4px 0;
+  cursor: pointer;
   z-index: 1100;
 }
 
 .toggle-btn.shifted {
-  left: calc(200px + 2rem);
+  left: 200px;
 }
 
 .logout-btn {
@@ -578,4 +585,14 @@ table tr:hover {
 .icon-button:focus {
   outline: 2px solid #09adb9;
   outline-offset: 2px;
+}
+
+/* Content area that shifts when sidebar is open */
+.main-content {
+  transition: margin-left 0.3s ease;
+  margin-left: 0;
+}
+
+.main-content.shifted {
+  margin-left: 200px;
 }

--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -22,11 +22,10 @@ export default function AdminLayout() {
   return (
     <>
       <button
-        className={`button toggle-btn${open ? ' shifted' : ''}`}
+        className={`toggle-btn${open ? ' shifted' : ''}`}
         onClick={() => setOpen(!open)}
-        style={{ width: 'auto' }}
       >
-        菜单
+        {open ? '\u25C0' : '\u25B6'}
       </button>
       <div className={`sidebar${open ? ' open' : ''}`}>
         <div style={{ marginBottom: '1rem' }}>您好，管理员{username}</div>
@@ -37,7 +36,7 @@ export default function AdminLayout() {
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>
       </div>
-      <div>
+      <div className={`main-content${open ? ' shifted' : ''}`}>
         <Outlet />
       </div>
     </>

--- a/frontend/src/pages/ClassManagementPage.jsx
+++ b/frontend/src/pages/ClassManagementPage.jsx
@@ -71,7 +71,7 @@ export default function ClassManagementPage() {
   const paged = filtered.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <Box p={4}>
+    <Box p={4} maxW="960px" mx="auto">
       <Flex justify="space-between" align="center" mb={4} flexWrap="wrap" gap={2}>
         <Heading size="lg">班级管理</Heading>
         <Button onClick={() => setShowForm(!showForm)} colorScheme="teal" size="sm">

--- a/frontend/src/pages/MyClassesPage.jsx
+++ b/frontend/src/pages/MyClassesPage.jsx
@@ -53,7 +53,7 @@ export default function MyClassesPage() {
   };
 
   return (
-    <Box p={4}>
+    <Box p={4} maxW="960px" mx="auto">
       <Flex justify="space-between" align="center" mb={4} flexWrap="wrap" gap={2}>
         <Heading size="lg">我的班级</Heading>
         <Button size="sm" colorScheme="teal" onClick={() => setShowJoin(!showJoin)}>

--- a/frontend/src/pages/StudentClassDetailPage.jsx
+++ b/frontend/src/pages/StudentClassDetailPage.jsx
@@ -41,7 +41,7 @@ export default function StudentClassDetailPage() {
   }
 
   return (
-    <Box p={4} pb={20}>
+    <Box p={4} pb={20} maxW="960px" mx="auto">
       <Breadcrumb mb={4} fontSize="sm">
         <BreadcrumbItem>
           <BreadcrumbLink onClick={() => navigate('/student/homeworks')}>首页</BreadcrumbLink>

--- a/frontend/src/pages/StudentLayout.jsx
+++ b/frontend/src/pages/StudentLayout.jsx
@@ -22,11 +22,10 @@ export default function StudentLayout() {
   return (
     <>
       <button
-        className={`button toggle-btn${open ? " shifted" : ""}`}
+        className={`toggle-btn${open ? " shifted" : ""}`}
         onClick={() => setOpen(!open)}
-        style={{ width: "auto" }}
       >
-        菜单
+        {open ? "\u25C0" : "\u25B6"}
       </button>
       <div className={`sidebar${open ? " open" : ""}`}>
         <div style={{ marginBottom: "1rem" }}>您好，同学{username}</div>
@@ -38,7 +37,7 @@ export default function StudentLayout() {
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>
       </div>
-      <div>
+      <div className={`main-content${open ? " shifted" : ""}`}>
         <Outlet />
       </div>
     </>

--- a/frontend/src/pages/TeacherClassDetailPage.jsx
+++ b/frontend/src/pages/TeacherClassDetailPage.jsx
@@ -82,7 +82,7 @@ export default function TeacherClassDetailPage() {
     );
 
   return (
-    <Box p={4} pb={20}>
+    <Box p={4} pb={20} maxW="960px" mx="auto">
       <Breadcrumb mb={4} fontSize="sm">
         <BreadcrumbItem>
           <BreadcrumbLink onClick={() => navigate('/teacher/lesson')}>首页</BreadcrumbLink>

--- a/frontend/src/pages/TeacherLayout.jsx
+++ b/frontend/src/pages/TeacherLayout.jsx
@@ -22,11 +22,10 @@ export default function TeacherLayout() {
   return (
     <>
       <button
-        className={`button toggle-btn${open ? " shifted" : ""}`}
+        className={`toggle-btn${open ? " shifted" : ""}`}
         onClick={() => setOpen(!open)}
-        style={{ width: "auto" }}
       >
-        菜单
+        {open ? "\u25C0" : "\u25B6"}
       </button>
       <div className={`sidebar${open ? " open" : ""}`}>
         <div style={{ marginBottom: "1rem" }}>您好，教师{username}</div>
@@ -39,7 +38,7 @@ export default function TeacherLayout() {
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>
       </div>
-      <div>
+      <div className={`main-content${open ? " shifted" : ""}`}>
         <Outlet />
       </div>
     </>


### PR DESCRIPTION
## Summary
- refactor sidebar toggles to use centered arrow button
- shift main content when sidebar opens
- limit page widths on Chakra pages for better spacing

## Testing
- `npm run lint --prefix frontend` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877ddf742b4832289396d1160f8957a