### PR TITLE
Format timestamps for display

### DIFF
--- a/frontend/src/pages/AdminCoursewares.jsx
+++ b/frontend/src/pages/AdminCoursewares.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { fetchCoursewares, shareCourseware, downloadCourseware } from '../api/admin';
 import { Link } from 'react-router-dom';
 import '../index.css';
+import { formatDateTime } from '../utils';
 
 export default function AdminCoursewares() {
   const [list, setList] = useState([]);
@@ -75,7 +76,7 @@ export default function AdminCoursewares() {
                   <td>{c.id}</td>
                   <td>{c.topic}</td>
                   <td>{c.teacher_id}</td>
-                  <td>{c.created_at}</td>
+                  <td>{formatDateTime(c.created_at)}</td>
                   <td>
                     <button
                       className="button"

--- a/frontend/src/pages/AdminPublicDocs.jsx
+++ b/frontend/src/pages/AdminPublicDocs.jsx
@@ -5,6 +5,7 @@ import {
   deletePublicDoc,
 } from '../api/admin';
 import '../index.css';
+import { formatDateTime } from '../utils';
 
 export default function AdminPublicDocs() {
   const [list, setList] = useState([]);
@@ -72,7 +73,7 @@ export default function AdminPublicDocs() {
               {list.map((d) => (
                 <tr key={d.id}>
                   <td>{d.filename}</td>
-                  <td>{d.uploaded_at}</td>
+                  <td>{formatDateTime(d.uploaded_at)}</td>
                   <td>
                     <button className="button" onClick={() => handleDelete(d.id)}>删除</button>
                   </td>

--- a/frontend/src/pages/DocumentManage.jsx
+++ b/frontend/src/pages/DocumentManage.jsx
@@ -7,6 +7,7 @@ import {
   deleteDocument,
 } from '../api/teacher';
 import '../index.css';
+import { formatDateTime } from '../utils';
 
 export default function DocumentManage() {
   const [tab, setTab] = useState('my');
@@ -135,7 +136,7 @@ export default function DocumentManage() {
               {list.map((d) => (
                 <tr key={d.id}>
                   <td>{d.filename}</td>
-                  <td>{d.uploaded_at}</td>
+                  <td>{formatDateTime(d.uploaded_at)}</td>
                   <td>
                     <span className={`tag ${d.is_active ? 'tag-green' : 'tag-gray'}`}>{d.is_active ? '已激活' : '未激活'}</span>
                   </td>

--- a/frontend/src/pages/ExerciseList.jsx
+++ b/frontend/src/pages/ExerciseList.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { fetchExerciseList } from "../api/teacher";
+import { formatDateTime } from "../utils";
 import "../index.css";
 
 export default function ExerciseList() {
@@ -45,7 +46,7 @@ export default function ExerciseList() {
               {list.map((ex) => (
                 <tr key={ex.id}>
                   <td>{ex.subject}</td>
-                  <td>{ex.created_at}</td>
+                  <td>{formatDateTime(ex.created_at)}</td>
                   <td>
                     <Link to={`/teacher/exercise/preview/${ex.id}`}>预览</Link>
                   </td>

--- a/frontend/src/pages/LessonList.jsx
+++ b/frontend/src/pages/LessonList.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { fetchLessonList } from "../api/teacher";
+import { formatDateTime } from "../utils";
 import "../index.css";
 
 export default function LessonList() {
@@ -46,7 +47,7 @@ export default function LessonList() {
               {lessons.map((lesson) => (
                 <tr key={lesson.id}>
                   <td>{lesson.topic}</td>
-                  <td>{lesson.created_at}</td>
+                  <td>{formatDateTime(lesson.created_at)}</td>
                   <td>
                     <Link to={`/teacher/lesson/preview/${lesson.id}`}>
                       预览

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,12 @@
+export function formatDateTime(str) {
+  if (!str) return '';
+  const d = new Date(str);
+  if (Number.isNaN(d.getTime())) return str;
+  const pad = (n) => String(n).padStart(2, '0');
+  const yyyy = d.getFullYear();
+  const mm = pad(d.getMonth() + 1);
+  const dd = pad(d.getDate());
+  const hh = pad(d.getHours());
+  const min = pad(d.getMinutes());
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
+}


### PR DESCRIPTION
## Summary
- add `formatDateTime` utility for converting ISO strings to `yyyy-mm-dd hh:mm`
- use the new formatter for lesson, exercise, document, and courseware lists

## Testing
- `npm run lint` *(fails: cannot pass linter)*

------
https://chatgpt.com/codex/tasks/task_e_6877c625bedc8322ae1e4c1e1a0dd180