### PR TITLE
Add single/multiple choice split and scoring

### DIFF
--- a/backend/create_db.sql
+++ b/backend/create_db.sql
@@ -30,6 +30,7 @@ CREATE TABLE `exercise` (
   `subject` varchar(100) DEFAULT NULL,
   `prompt` json NOT NULL,
   `answers` json NOT NULL,
+  `points` json NOT NULL,
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
   KEY `teacher_id` (`teacher_id`),

--- a/backend/models.py
+++ b/backend/models.py
@@ -47,6 +47,7 @@ class Exercise(SQLModel, table=True):
 
     prompt: Any = Field(sa_column=Column(JSON), default_factory=list)
     answers: Any = Field(sa_column=Column(JSON), default_factory=dict)
+    points: Any = Field(sa_column=Column(JSON), default_factory=dict)
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/backend/routers/exercise_router.py
+++ b/backend/routers/exercise_router.py
@@ -24,6 +24,7 @@ class SaveExerciseRequest(BaseModel):
     topic: str
     questions: List[dict]
     answers: dict
+    points: dict
 
 
 class AssignRequest(BaseModel):
@@ -36,7 +37,8 @@ def api_generate(req: GenerateExerciseRequest, user: User = Depends(get_current_
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
     data = preview_exercise(
         topic=req.topic,
-        num_mcq=req.num_mcq,
+        num_single_choice=req.num_single_choice,
+        num_multiple_choice=req.num_multiple_choice,
         num_fill_blank=req.num_fill_blank,
         num_short_answer=req.num_short_answer,
         num_programming=req.num_programming,
@@ -55,7 +57,7 @@ def api_generate(req: GenerateExerciseRequest, user: User = Depends(get_current_
 def api_save(req: SaveExerciseRequest, user: User = Depends(get_current_user)):
     if user.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
-    return save_exercise(user.id, req.topic, req.questions, req.answers)
+    return save_exercise(user.id, req.topic, req.questions, req.answers, req.points)
 
 
 @router.post("/save_and_assign", response_model=HomeworkOut)
@@ -63,7 +65,7 @@ def api_save_and_assign(req: SaveExerciseRequest, assign: AssignRequest | None =
     if user.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
     class_id = assign.class_id if assign else None
-    return save_and_assign_exercise(user.id, req.topic, req.questions, req.answers, class_id)
+    return save_and_assign_exercise(user.id, req.topic, req.questions, req.answers, req.points, class_id)
 
 
 @router.get("/list", response_model=List[ExerciseOut])

--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -81,7 +81,8 @@ def api_generate(req: PracticeGenerateRequest, user: User = Depends(get_current_
     pr = generate_practice(
         user.id,
         topic=req.topic,
-        num_mcq=req.num_mcq,
+        num_single_choice=req.num_single_choice,
+        num_multiple_choice=req.num_multiple_choice,
         num_fill_blank=req.num_fill_blank,
         num_short_answer=req.num_short_answer,
         num_programming=req.num_programming,

--- a/backend/schemas/exercise_schema.py
+++ b/backend/schemas/exercise_schema.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel
 
 class GenerateExerciseRequest(BaseModel):
     topic: str
-    num_mcq: int = 0
+    num_single_choice: int = 0
+    num_multiple_choice: int = 0
     num_fill_blank: int = 0
     num_short_answer: int = 0
     num_programming: int = 0
@@ -36,6 +37,7 @@ class ExerciseOut(BaseModel):
     subject: str
     prompt: List[QuestionBlock]
     answers: Dict[str, Any]
+    points: Dict[str, Any]
     created_at: datetime
 
     class Config:

--- a/backend/schemas/student_schema.py
+++ b/backend/schemas/student_schema.py
@@ -36,7 +36,8 @@ class MessageOut(BaseModel):
 
 class PracticeGenerateRequest(BaseModel):
     topic: str
-    num_mcq: int = 0
+    num_single_choice: int = 0
+    num_multiple_choice: int = 0
     num_fill_blank: int = 0
     num_short_answer: int = 0
     num_programming: int = 0

--- a/backend/services/practice_service.py
+++ b/backend/services/practice_service.py
@@ -18,14 +18,16 @@ def _parse_model_response(resp: Dict[str, Any]) -> Dict[str, Any]:
 def generate_practice(
     student_id: int,
     topic: str,
-    num_mcq: int = 0,
+    num_single_choice: int = 0,
+    num_multiple_choice: int = 0,
     num_fill_blank: int = 0,
     num_short_answer: int = 0,
     num_programming: int = 0,
 ) -> Practice:
     data = preview_exercise(
         topic=topic,
-        num_mcq=num_mcq,
+        num_single_choice=num_single_choice,
+        num_multiple_choice=num_multiple_choice,
         num_fill_blank=num_fill_blank,
         num_short_answer=num_short_answer,
         num_programming=num_programming,

--- a/backend/services/submission_service.py
+++ b/backend/services/submission_service.py
@@ -47,9 +47,14 @@ def grade_submission(submission_id: int):
         )
         resp = call_deepseek_api(prompt, model="deepseek-reasoner")
         content = resp["choices"][0]["message"]["content"]
-        # 去除 Markdown code fence
-        text = re.sub(r"^```(?:json)?\s*", "", content)
-        text = re.sub(r"\s*```$", "", text)
+        start = content.find("{")
+        end = content.rfind("}")
+        if start == -1 or end == -1 or start > end:
+            # fallback: remove Markdown fences if any
+            text = re.sub(r"^```(?:json)?\s*", "", content)
+            text = re.sub(r"\s*```$", "", text)
+        else:
+            text = content[start : end + 1]
         data = json.loads(text)
 
         results      = data.get("results", {})

--- a/backend/services/submission_service.py
+++ b/backend/services/submission_service.py
@@ -34,36 +34,88 @@ def grade_submission(submission_id: int):
         hw  = sess.get(Homework, sub.homework_id)
         ex  = sess.get(Exercise, hw.exercise_id)
 
-        # 构建批改 prompt
+        # —— 新增：只处理单选/多选题的索引->字母转换 ——
+        def convert_indexed_answers(prompt_blocks, indexed_answers: Dict[str, Any]) -> Dict[str, Any]:
+            """
+            只对 single_choice / multiple_choice 题型做索引->字母转换，
+            其他题型保持原值。
+            """
+            # 构造 qid -> (qtype, options) 映射
+            meta = {}
+            for block in prompt_blocks:
+                qtype = block.get("type")
+                for item in block.get("items", []):
+                    qid = str(item.get("id"))
+                    meta[qid] = {
+                        "type": qtype,
+                        "options": item.get("options", []),
+                    }
+
+            letter_answers = {}
+            for qid, ans in indexed_answers.items():
+                info = meta.get(qid)
+                # 如果不是选择题或未找到元数据，保持原值
+                if not info or info["type"] not in ("single_choice", "multiple_choice"):
+                    letter_answers[qid] = ans
+                    continue
+
+                opts = info["options"]
+                if isinstance(ans, list):
+                    # 多选题：索引列表 -> 字母列表
+                    letter_answers[qid] = [
+                        opts[i].split(".", 1)[0] for i in ans if 0 <= i < len(opts)
+                    ]
+                else:
+                    # 单选题：单个索引 -> 字母
+                    letter_answers[qid] = (
+                        opts[ans].split(".", 1)[0]
+                        if isinstance(ans, int) and 0 <= ans < len(opts)
+                        else ans
+                    )
+            return letter_answers
+
+        # 原始索引答案
+        indexed = sub.answers or {}
+        # 转换得到字母答案（只影响 single_choice/multiple_choice 题型）
+        letter_answers = convert_indexed_answers(ex.prompt, indexed)
+
+        # 构建批改 prompt（用 letter_answers 而非原始 sub.answers）
         point_map = ex.points or {}
         sa_point = point_map.get("short_answer", 1)
         prompt = (
             "请根据下面的 JSON：\n"
             f"题目: {json.dumps(ex.prompt, ensure_ascii=False)}\n"
             f"标准答案: {json.dumps(ex.answers, ensure_ascii=False)}\n"
-            f"学生答案: {json.dumps(sub.answers, ensure_ascii=False)}\n\n"
-            f"请判断学生答案并给出解析。其中简答题按照满分 {sa_point} 分给出 0 到 {sa_point} 的得分，其他题型判断对错即可。"
-            "返回 JSON：{ \"results\": {qid: 'correct|wrong|partial'}, \"scores\": {qid: number}, \"explanations\": {qid: '解析'} }"
+            f"学生答案: {json.dumps(letter_answers, ensure_ascii=False)}\n\n"
+            f"请判断学生答案并给出解析。其中简答题按照满分 {sa_point} 分给出 0 到 {sa_point} 的得分，"
+            "其他题型判断对错即可。"
+            "返回 JSON：{ \"results\": {qid: 'correct|wrong|partial'}, \"scores\": {qid: number}, "
+            "\"explanations\": {qid: '解析'} }。"
+            "请只返回 JSON，不要有其它任何多余内容，包括任何markdown符号。"
         )
-        resp = call_deepseek_api(prompt, model="deepseek-reasoner")
+
+        # 调用 Deepseek / 大模型 API
+        resp = call_deepseek_api(prompt, model="deepseek-chat")
         content = resp["choices"][0]["message"]["content"]
+
+        # 提取 JSON 字符串
         start = content.find("{")
         end = content.rfind("}")
         if start == -1 or end == -1 or start > end:
-            # fallback: remove Markdown fences if any
+            # fallback: 去除可能存在的 ```json ``` 标记
             text = re.sub(r"^```(?:json)?\s*", "", content)
             text = re.sub(r"\s*```$", "", text)
         else:
             text = content[start : end + 1]
-        data = json.loads(text)
 
+        data = json.loads(text)
         results      = data.get("results", {})
         explanations = data.get("explanations", {})
         scores_dict  = data.get("scores", {})
 
-        # 计算得分，考虑题型分值
-        score = 0
-        point_map = ex.points or {}
+        # 计算总分
+        total_score = 0
+        # 构建 qid->题型映射
         qtype_map = {}
         for block in ex.prompt:
             for item in block.get("items", []):
@@ -73,14 +125,14 @@ def grade_submission(submission_id: int):
             base = point_map.get(qtype_map.get(str(qid), ""), 1)
             if str(qid) in scores_dict:
                 try:
-                    score += float(scores_dict[str(qid)])
-                except Exception:
-                    score += 0
+                    total_score += float(scores_dict[str(qid)])
+                except ValueError:
+                    pass
             else:
                 if result in ("correct", "正确", True):
-                    score += base
+                    total_score += base
 
-        sub.score    = int(round(score))
+        sub.score    = int(round(total_score))
         sub.feedback = {
             "results": results,
             "explanations": explanations,
@@ -91,7 +143,7 @@ def grade_submission(submission_id: int):
         sess.add(sub)
         sess.commit()
 
-        # after grading, trigger student analysis
+        # 批改后触发分析
         analyze_and_save_homeworks(sub.student_id)
         cls = sess.get(Class, hw.class_id) if hw.class_id else None
         if cls and cls.teacher_id == ex.teacher_id:

--- a/backend/utils/pdf_utils.py
+++ b/backend/utils/pdf_utils.py
@@ -7,11 +7,12 @@ from backend.config import PDFKIT_CONFIG
 def format_questions_html(questions: List[Dict[str, Any]]) -> str:
     """
     按题型分别渲染练习题，
-    支持 'multiple_choice', 'fill_in_the_blank', 'short_answer', 'programming'。
+    支持 'single_choice', 'multiple_choice', 'fill_in_the_blank', 'short_answer', 'programming'。
     """
     # 题型中文映射
     type_map = {
-        "multiple_choice": "选择题",
+        "single_choice": "单选题",
+        "multiple_choice": "多选题",
         "fill_in_blank": "填空题",
         "short_answer": "简答题",
         "coding": "编程题"
@@ -29,7 +30,7 @@ def format_questions_html(questions: List[Dict[str, Any]]) -> str:
             html += f"<li>{question}"
 
             # 只有选择题才渲染 options
-            if qtype == "multiple_choice":
+            if qtype in ("single_choice", "multiple_choice"):
                 html += "<ul>"
                 for opt in item.get("options", []):
                     html += f"<li>{opt}</li>"

--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -42,19 +42,21 @@ export async function downloadCoursewarePdf(cw_id) {
 
 /**
  * 生成练习题（JSON）
- * @param {{ topic: string, num_mcq: number, num_fill_blank: number, num_short_answer: number, num_programming: number }} params
+ * @param {{ topic: string, num_single_choice: number, num_multiple_choice: number, num_fill_blank: number, num_short_answer: number, num_programming: number }} params
  * @returns {Promise<{ topic: string, questions: any[], answers: any }>}
  */
 export async function generateExerciseJson({
   topic,
-  num_mcq,
+  num_single_choice,
+  num_multiple_choice,
   num_fill_blank,
   num_short_answer,
   num_programming,
 }) {
   const resp = await api.post("/teacher/exercise/generate", {
     topic,
-    num_mcq,
+    num_single_choice,
+    num_multiple_choice,
     num_fill_blank,
     num_short_answer,
     num_programming,
@@ -65,12 +67,13 @@ export async function generateExerciseJson({
 
 /**
  * 下载练习题 PDF
- * @param {{ topic: string, num_mcq: number, num_fill_blank: number, num_short_answer: number, num_programming: number }} params
+ * @param {{ topic: string, num_single_choice: number, num_multiple_choice: number, num_fill_blank: number, num_short_answer: number, num_programming: number }} params
  * @returns {Promise<Blob>}
  */
 export async function downloadExercisePdf({
   topic,
-  num_mcq,
+  num_single_choice,
+  num_multiple_choice,
   num_fill_blank,
   num_short_answer,
   num_programming,
@@ -79,7 +82,8 @@ export async function downloadExercisePdf({
     "/teacher/exercise/generate",
     {
       topic,
-      num_mcq,
+      num_single_choice,
+      num_multiple_choice,
       num_fill_blank,
       num_short_answer,
       num_programming,
@@ -119,11 +123,12 @@ export async function fetchExerciseStats(exerciseId) {
  * @param {{topic: string, questions: any[], answers: any}} data
  * @returns {Promise<{id: number}>}
  */
-export async function saveExercise({ topic, questions, answers }) {
+export async function saveExercise({ topic, questions, answers, points }) {
   const resp = await api.post("/teacher/exercise/save", {
     topic,
     questions,
     answers,
+    points,
   });
   return resp.data;
 }
@@ -133,11 +138,12 @@ export async function saveExercise({ topic, questions, answers }) {
  * @param {{topic: string, questions: any[], answers: any}} data
  * @returns {Promise<any>} 作业信息
  */
-export async function saveAndAssignExercise({ topic, questions, answers, classId }) {
+export async function saveAndAssignExercise({ topic, questions, answers, points, classId }) {
   const resp = await api.post("/teacher/exercise/save_and_assign", {
     topic,
     questions,
     answers,
+    points,
     class_id: classId,
   });
   return resp.data;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -402,6 +402,10 @@ table tr:hover {
   background: #e0f2ff;
 }
 
+.header-single_choice {
+  background: #ede9fe;
+}
+
 .header-fill_in_blank {
   background: #ecfdf5;
 }

--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -11,7 +11,8 @@ export default function EvaluateAssistant() {
   const [analysisLoading, setAnalysisLoading] = useState(false);
   const [form, setForm] = useState({
     topic: "",
-    num_mcq: 5,
+    num_single_choice: 5,
+    num_multiple_choice: 0,
     num_fill_blank: 5,
     num_short_answer: 1,
     num_programming: 0,
@@ -84,12 +85,23 @@ export default function EvaluateAssistant() {
             />
           </label>
           <label>
-            选择题数量
+            单选题数量
             <input
               className="input"
               type="number"
-              name="num_mcq"
-              value={form.num_mcq}
+              name="num_single_choice"
+              value={form.num_single_choice}
+              onChange={handleChange}
+              min="0"
+            />
+          </label>
+          <label>
+            多选题数量
+            <input
+              className="input"
+              type="number"
+              name="num_multiple_choice"
+              value={form.num_multiple_choice}
               onChange={handleChange}
               min="0"
             />

--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -15,10 +15,16 @@ import "../index.css";
 export default function ExercisePage() {
   const [form, setForm] = useState({
     topic: "",
-    num_mcq: 5,
+    num_single_choice: 5,
+    num_multiple_choice: 0,
     num_fill_blank: 5,
     num_short_answer: 1,
     num_programming: 0,
+    score_single_choice: 1,
+    score_multiple_choice: 1,
+    score_fill_blank: 1,
+    score_short_answer: 2,
+    score_programming: 5,
   });
   const [preview, setPreview] = useState(null);
   const [showPreview, setShowPreview] = useState(false);
@@ -34,7 +40,7 @@ export default function ExercisePage() {
     const { name, value } = e.target;
     setForm((prev) => ({
       ...prev,
-      [name]: name.startsWith("num_") ? Number(value) : value,
+      [name]: name.startsWith("num_") || name.startsWith("score_") ? Number(value) : value,
     }));
   };
 
@@ -64,6 +70,13 @@ export default function ExercisePage() {
         topic: form.topic,
         questions: preview.questions,
         answers: preview.answers,
+        points: {
+          single_choice: form.score_single_choice,
+          multiple_choice: form.score_multiple_choice,
+          fill_in_blank: form.score_fill_blank,
+          short_answer: form.score_short_answer,
+          coding: form.score_programming,
+        },
       });
       setExId(res.id);
       setSaved(true);
@@ -82,6 +95,13 @@ export default function ExercisePage() {
           topic: form.topic,
           questions: preview.questions,
           answers: preview.answers,
+          points: {
+            single_choice: form.score_single_choice,
+            multiple_choice: form.score_multiple_choice,
+            fill_in_blank: form.score_fill_blank,
+            short_answer: form.score_short_answer,
+            coding: form.score_programming,
+          },
         });
         id = res.id;
         setExId(id);
@@ -146,10 +166,18 @@ export default function ExercisePage() {
   };
 
   const total =
-    form.num_mcq +
+    form.num_single_choice +
+    form.num_multiple_choice +
     form.num_fill_blank +
     form.num_short_answer +
     form.num_programming;
+
+  const totalScore =
+    form.num_single_choice * form.score_single_choice +
+    form.num_multiple_choice * form.score_multiple_choice +
+    form.num_fill_blank * form.score_fill_blank +
+    form.num_short_answer * form.score_short_answer +
+    form.num_programming * form.score_programming;
 
   return (
     <div className="container">
@@ -170,13 +198,39 @@ export default function ExercisePage() {
           <h2>配置题量</h2>
           <div className="grid-2">
             <label>
-              选择题数量
-              <Tooltip text="单选或多选题目" />
+              单选题数量
               <Stepper
-                value={form.num_mcq}
-                onChange={(v) => setForm((p) => ({ ...p, num_mcq: v }))}
+                value={form.num_single_choice}
+                onChange={(v) => setForm((p) => ({ ...p, num_single_choice: v }))}
                 min={0}
                 max={20}
+              />
+            </label>
+            <label>
+              单选题分值
+              <Stepper
+                value={form.score_single_choice}
+                onChange={(v) => setForm((p) => ({ ...p, score_single_choice: v }))}
+                min={1}
+                max={100}
+              />
+            </label>
+            <label>
+              多选题数量
+              <Stepper
+                value={form.num_multiple_choice}
+                onChange={(v) => setForm((p) => ({ ...p, num_multiple_choice: v }))}
+                min={0}
+                max={20}
+              />
+            </label>
+            <label>
+              多选题分值
+              <Stepper
+                value={form.score_multiple_choice}
+                onChange={(v) => setForm((p) => ({ ...p, score_multiple_choice: v }))}
+                min={1}
+                max={100}
               />
             </label>
             <label>
@@ -190,6 +244,15 @@ export default function ExercisePage() {
               />
             </label>
             <label>
+              填空题分值
+              <Stepper
+                value={form.score_fill_blank}
+                onChange={(v) => setForm((p) => ({ ...p, score_fill_blank: v }))}
+                min={1}
+                max={100}
+              />
+            </label>
+            <label>
               简答题数量
               <Tooltip text="需要简短回答的题目" />
               <Stepper
@@ -197,6 +260,15 @@ export default function ExercisePage() {
                 onChange={(v) => setForm((p) => ({ ...p, num_short_answer: v }))}
                 min={0}
                 max={20}
+              />
+            </label>
+            <label>
+              简答题分值
+              <Stepper
+                value={form.score_short_answer}
+                onChange={(v) => setForm((p) => ({ ...p, score_short_answer: v }))}
+                min={1}
+                max={100}
               />
             </label>
             <label>
@@ -209,8 +281,17 @@ export default function ExercisePage() {
                 max={20}
               />
             </label>
+            <label>
+              编程题分值
+              <Stepper
+                value={form.score_programming}
+                onChange={(v) => setForm((p) => ({ ...p, score_programming: v }))}
+                min={1}
+                max={100}
+              />
+            </label>
           </div>
-          <div className="total-count">共计 {total} 题</div>
+          <div className="total-count">共计 {total} 题，总分 {totalScore}</div>
           <button className="button" type="submit" disabled={loading}>
             {loading ? "生成中…" : "生成练习"}
           </button>

--- a/frontend/src/pages/StudentHomeworkAnswer.jsx
+++ b/frontend/src/pages/StudentHomeworkAnswer.jsx
@@ -53,6 +53,35 @@ export default function StudentHomeworkAnswer() {
 
   const renderOptions = () => {
     if (!question.options) return null;
+    if (question.type === "multiple_choice") {
+      const vals = answers[question.id] || [];
+      const toggle = (idx) => {
+        setAnswers((prev) => {
+          const arr = prev[question.id] || [];
+          const next = arr.includes(idx)
+            ? arr.filter((i) => i !== idx)
+            : [...arr, idx];
+          return { ...prev, [question.id]: next };
+        });
+      };
+      return (
+        <ul style={{ listStyle: "none", paddingLeft: 0 }}>
+          {question.options.map((opt, idx) => (
+            <li key={idx}>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={vals.includes(idx)}
+                  onChange={() => toggle(idx)}
+                />
+                {opt}
+              </label>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+    // single_choice
     return (
       <ul style={{ listStyle: "none", paddingLeft: 0 }}>
         {question.options.map((opt, idx) => (

--- a/frontend/src/pages/StudentHomeworkResult.jsx
+++ b/frontend/src/pages/StudentHomeworkResult.jsx
@@ -29,7 +29,8 @@ export default function StudentHomeworkResult() {
 
   const { exercise, student_answers, feedback, score } = data;
   const results = feedback.results || {};
-
+  const scoreMap = feedback.scores || {};
+  
   const optionLabel = (v) => {
     if (v === undefined || v === null) return v;
     if (Array.isArray(v)) return v.map(optionLabel).join(', ');
@@ -49,7 +50,8 @@ export default function StudentHomeworkResult() {
     r === "correct" || r === "正确" || r === true ? "对" : "错";
 
   const typeNames = {
-    multiple_choice: "选择题",
+    single_choice: "单选题",
+    multiple_choice: "多选题",
     fill_in_blank: "填空题",
     short_answer: "简答题",
   };
@@ -90,7 +92,7 @@ export default function StudentHomeworkResult() {
                   </button>
                   {block.type === "short_answer" && (
                     <span className="score-badge">
-                      {fmt(results[item.id]) === "对" ? 1 : 0}
+                      {scoreMap[item.id] ?? (fmt(results[item.id]) === "对" ? (exercise.points?.short_answer || 1) : 0)}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- support question scoring by type in backend and frontend
- distinguish single and multiple choice exercises
- enable partial scores for short answers
- update student pages for new question types

## Testing
- `npm run lint` *(fails: 20 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68786b96a29483228377c665ee82e950