### PR TITLE
Fix duplicate AI chat sessions on initial load

### DIFF
--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -1,4 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
+
+// prevent duplicate initial session creation when React.StrictMode
+let initSessionPromise = null;
 import api from "../api/api";
 import { useParams, useNavigate } from "react-router-dom";
 import ReactMarkdown from "react-markdown";
@@ -22,8 +25,12 @@ export default function StudentAiTeacher() {
       if (!sid) {
         if (resp.data.length > 0) sid = resp.data[0].id;
         else {
-          const r = await api.post("/student/ai/session");
+          if (!initSessionPromise) {
+            initSessionPromise = api.post("/student/ai/session");
+          }
+          const r = await initSessionPromise;
           sid = r.data.id;
+          initSessionPromise = null;
         }
       }
       setCurrent(sid);


### PR DESCRIPTION
## Summary
- prevent creating multiple chat sessions due to `React.StrictMode` double effects

## Testing
- `npm run lint` *(fails: cannot pass existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878b1b603fc832296dcc523a1379c8f