### PR TITLE
Add AI optimize feature to lesson prep

### DIFF
--- a/backend/routers/lesson_router.py
+++ b/backend/routers/lesson_router.py
@@ -201,6 +201,7 @@ async def optimize_courseware(
     new_md = await optimize_lesson(
         req.topic, req.markdown, req.instruction, current_user.id
     )
+    lesson_markdown_cache[req.topic] = new_md
     return {"markdown": new_md}
 
 

--- a/backend/routers/lesson_router.py
+++ b/backend/routers/lesson_router.py
@@ -43,6 +43,7 @@ class CoursewareUpdate(BaseModel):
 
 
 class LessonOptimizeRequest(BaseModel):
+    topic: str
     markdown: str
     instruction: str
 
@@ -191,10 +192,15 @@ async def optimize_courseware(
 ):
     if not current_user.role or current_user.role.name != "teacher":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师角色访问")
-    if not req.markdown.strip() or not req.instruction.strip():
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="markdown 和 instruction 不能为空")
+    if not (req.topic.strip() and req.markdown.strip() and req.instruction.strip()):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="topic、markdown 和 instruction 不能为空",
+        )
 
-    new_md = await optimize_lesson(req.markdown, req.instruction)
+    new_md = await optimize_lesson(
+        req.topic, req.markdown, req.instruction, current_user.id
+    )
     return {"markdown": new_md}
 
 

--- a/backend/services/lesson_service.py
+++ b/backend/services/lesson_service.py
@@ -55,3 +55,16 @@ async def generate_lesson(topic: str, user_id: int) -> str:
     result = _ds.call_deepseek_api(prompt=prompt)
     markdown_content = result["choices"][0]["message"]["content"]
     return markdown_content
+
+
+async def optimize_lesson(markdown: str, instruction: str) -> str:
+    """根据教师的额外要求优化现有教案 Markdown。"""
+    prompt = (
+        "你是一名教学助手，请根据老师的以下要求对给出的教案内容进行修改优化，"
+        "并返回新的教案 Markdown：\n\n"
+        f"老师要求：{instruction}\n\n"
+        f"原教案内容：\n{markdown}\n\n"
+        "请直接输出优化后的 Markdown，不要使用 ``` 包裹。"
+    )
+    result = _ds.call_deepseek_api(prompt=prompt)
+    return result["choices"][0]["message"]["content"]

--- a/backend/services/lesson_service.py
+++ b/backend/services/lesson_service.py
@@ -57,11 +57,23 @@ async def generate_lesson(topic: str, user_id: int) -> str:
     return markdown_content
 
 
-async def optimize_lesson(markdown: str, instruction: str) -> str:
-    """根据教师的额外要求优化现有教案 Markdown。"""
+async def optimize_lesson(topic: str, markdown: str, instruction: str, user_id: int) -> str:
+    """根据教师的要求和知识库片段优化教案 Markdown。"""
+    snippets = _retrieve_snippets(topic, user_id)
+    if snippets:
+        header = (
+            f"以下是与“{topic}”相关的本地知识库片段，共 {len(snippets)} 条（仅供参考）：\n\n"
+            + "\n".join(f"- [{doc}] {text}" for doc, text in snippets)
+            + "\n\n"
+        )
+    else:
+        header = (
+            f"本地知识库中未找到与“{topic}”相关的内容，可依据自身经验优化。\n\n"
+        )
+
     prompt = (
-        "你是一名教学助手，请根据老师的以下要求对给出的教案内容进行修改优化，"
-        "并返回新的教案 Markdown：\n\n"
+        "你是一名教学助手，请结合提供的知识库内容和老师的要求，对教案进行修改优化：\n\n"
+        f"{header}"
         f"老师要求：{instruction}\n\n"
         f"原教案内容：\n{markdown}\n\n"
         "请直接输出优化后的 Markdown，不要使用 ``` 包裹。"

--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -39,6 +39,19 @@ export async function downloadCoursewarePdf(cw_id) {
   return resp.data;
 }
 
+/**
+ * 根据教师要求优化教案 Markdown
+ * @param {{ markdown: string, instruction: string }} params
+ * @returns {Promise<string>} 优化后的 Markdown
+ */
+export async function optimizeLesson({ markdown, instruction }) {
+  const resp = await api.post("/teacher/lesson/optimize", {
+    markdown,
+    instruction,
+  });
+  return resp.data.markdown;
+}
+
 
 /**
  * 生成练习题（JSON）

--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -41,11 +41,12 @@ export async function downloadCoursewarePdf(cw_id) {
 
 /**
  * 根据教师要求优化教案 Markdown
- * @param {{ markdown: string, instruction: string }} params
+ * @param {{ topic: string, markdown: string, instruction: string }} params
  * @returns {Promise<string>} 优化后的 Markdown
  */
-export async function optimizeLesson({ markdown, instruction }) {
+export async function optimizeLesson({ topic, markdown, instruction }) {
   const resp = await api.post("/teacher/lesson/optimize", {
+    topic,
     markdown,
     instruction,
   });

--- a/frontend/src/pages/AdminCoursewareEdit.jsx
+++ b/frontend/src/pages/AdminCoursewareEdit.jsx
@@ -18,6 +18,7 @@ export default function AdminCoursewareEdit() {
         const data = await fetchCoursewarePreview(id);
         setMarkdown(data.markdown || '');
       } catch (err) {
+        console.error(err);
         setError('加载失败');
       } finally {
         setLoading(false);
@@ -31,6 +32,7 @@ export default function AdminCoursewareEdit() {
       await updateCourseware(id, markdown);
       alert('已保存');
     } catch (err) {
+      console.error(err);
       alert('保存失败');
     }
   };
@@ -47,6 +49,7 @@ export default function AdminCoursewareEdit() {
       a.remove();
       URL.revokeObjectURL(url);
     } catch (err) {
+      console.error(err);
       alert('下载失败');
     }
   };

--- a/frontend/src/pages/AdminCoursewares.jsx
+++ b/frontend/src/pages/AdminCoursewares.jsx
@@ -16,6 +16,7 @@ export default function AdminCoursewares() {
       const data = await fetchCoursewares();
       setList(data);
     } catch (err) {
+      console.error(err);
       setError('加载失败');
     } finally {
       setLoading(false);
@@ -32,6 +33,7 @@ export default function AdminCoursewares() {
       alert('已共享');
       load();
     } catch (err) {
+      console.error(err);
       alert('操作失败');
     }
   };
@@ -48,6 +50,7 @@ export default function AdminCoursewares() {
       a.remove();
       URL.revokeObjectURL(url);
     } catch (err) {
+      console.error(err);
       alert('下载失败');
     }
   };

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -12,6 +12,7 @@ export default function AdminDashboard() {
         const d = await fetchDashboard();
         setData(d);
       } catch (err) {
+        console.error(err);
         setError('加载失败');
       }
     };

--- a/frontend/src/pages/AdminPublicDocs.jsx
+++ b/frontend/src/pages/AdminPublicDocs.jsx
@@ -19,6 +19,7 @@ export default function AdminPublicDocs() {
       const data = await fetchPublicDocs();
       setList(data);
     } catch (err) {
+      console.error(err);
       setError('加载失败');
     } finally {
       setLoading(false);
@@ -36,6 +37,7 @@ export default function AdminPublicDocs() {
       await uploadPublicDoc(file);
       load();
     } catch (err) {
+      console.error(err);
       alert('上传失败');
     }
   };
@@ -46,6 +48,7 @@ export default function AdminPublicDocs() {
       await deletePublicDoc(id);
       load();
     } catch (err) {
+      console.error(err);
       alert('删除失败');
     }
   };

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -15,6 +15,7 @@ export default function AdminUsers() {
       const data = await fetchUsers(r);
       setList(data);
     } catch (err) {
+      console.error(err);
       setError('加载失败');
     } finally {
       setLoading(false);
@@ -31,6 +32,7 @@ export default function AdminUsers() {
       await deleteUser(uid);
       load(role);
     } catch (err) {
+      console.error(err);
       alert('删除失败');
     }
   };

--- a/frontend/src/pages/ClassManagementPage.jsx
+++ b/frontend/src/pages/ClassManagementPage.jsx
@@ -38,6 +38,7 @@ export default function ClassManagementPage() {
       const data = await fetchTeacherClasses();
       setList(data);
     } catch (err) {
+      console.error(err);
       setError('加载失败');
     } finally {
       setLoading(false);
@@ -57,6 +58,7 @@ export default function ClassManagementPage() {
       await load();
       toast({ title: '创建成功', status: 'success', position: 'top' });
     } catch (err) {
+      console.error(err);
       toast({ title: '创建失败', status: 'error', position: 'top' });
     }
   };

--- a/frontend/src/pages/DocumentManage.jsx
+++ b/frontend/src/pages/DocumentManage.jsx
@@ -25,6 +25,7 @@ export default function DocumentManage() {
       const data = scope === 'public' ? await fetchPublicDocuments() : await fetchMyDocuments();
       setList(data);
     } catch (e) {
+      console.error(e);
       setError('加载失败');
     } finally {
       setLoading(false);
@@ -45,6 +46,7 @@ export default function DocumentManage() {
       setProgress(0);
       load('my');
     } catch (err) {
+      console.error(err);
       alert('上传失败');
       setUploading(false);
     }
@@ -74,6 +76,7 @@ export default function DocumentManage() {
       await deleteDocument(id);
       load('my');
     } catch (err) {
+      console.error(err);
       alert('删除失败');
     }
   };

--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import api from "../api/api";
 import { generateSelfPractice, fetchStudentAnalysis } from "../api/student";
 import { useNavigate } from "react-router-dom";
 import ReactMarkdown from "react-markdown";

--- a/frontend/src/pages/LessonPreview.jsx
+++ b/frontend/src/pages/LessonPreview.jsx
@@ -23,6 +23,7 @@ export default function LessonPreview() {
         const previewData = await fetchLessonPreview(cw_id);
         setMarkdown(previewData.markdown);
       } catch (error) {
+        console.error(error);
         setError("加载预览失败，请稍后重试");  // 显示加载错误信息
       } finally {
         setLoading(false);
@@ -57,6 +58,7 @@ export default function LessonPreview() {
       alert("已保存");
       setEditMode(false);
     } catch (err) {
+      console.error(err);
       alert("保存失败");
     }
   };

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -73,7 +73,7 @@ export default function TeacherLesson() {
     setError("");
     setLoading(true);
     try {
-      const newMd = await optimizeLesson({ markdown, instruction });
+      const newMd = await optimizeLesson({ topic, markdown, instruction });
       setMarkdown(newMd);
     } catch (err) {
       console.error(err);

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -3,6 +3,7 @@ import {
   prepareLessonMarkdown,
   downloadCoursewarePdf,
   saveCourseware,
+  optimizeLesson,
 } from "../api/teacher";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";  // 引入 GitHub 风格的 Markdown 支持
@@ -66,6 +67,22 @@ export default function TeacherLesson() {
     }
   };
 
+  const handleOptimize = async () => {
+    const instruction = window.prompt("输入优化要求，例如：增加案例或调整结构");
+    if (!instruction) return;
+    setError("");
+    setLoading(true);
+    try {
+      const newMd = await optimizeLesson({ markdown, instruction });
+      setMarkdown(newMd);
+    } catch (err) {
+      console.error(err);
+      setError("AI 优化失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="container">
       <div className="card">
@@ -116,11 +133,25 @@ export default function TeacherLesson() {
                 style={{
                   padding: "0.5rem 1rem",
                   fontSize: "0.9rem",
-                  width: "40%",
+                  width: "30%",
                   minWidth: "120px",
                 }}
               >
                 <i className="icon icon-save" /> 保存教案
+              </button>
+
+              {/* AI 优化 */}
+              <button
+                className="button btn-secondary"
+                onClick={handleOptimize}
+                style={{
+                  padding: "0.5rem 1rem",
+                  fontSize: "0.9rem",
+                  width: "30%",
+                  minWidth: "120px",
+                }}
+              >
+                <i className="icon icon-magic" /> AI优化
               </button>
 
               {/* 下载 PDF */}
@@ -131,7 +162,7 @@ export default function TeacherLesson() {
                 style={{
                   padding: "0.5rem 1rem",
                   fontSize: "0.9rem",
-                  width: "40%",
+                  width: "30%",
                   minWidth: "120px",
                 }}
               >

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -3,6 +3,7 @@ import {
   prepareLessonMarkdown,
   downloadCoursewarePdf,
   saveCourseware,
+  updateCourseware,
   optimizeLesson,
 } from "../api/teacher";
 import ReactMarkdown from "react-markdown";
@@ -37,9 +38,14 @@ export default function TeacherLesson() {
   const handleSave = async () => {
     setError("");
     try {
-      const savedCourseware = await saveCourseware({ topic });
-      setSaved(true);
-      setCwId(savedCourseware.id);
+      if (cwId) {
+        await updateCourseware(cwId, markdown);
+        setSaved(true);
+      } else {
+        const savedCourseware = await saveCourseware({ topic });
+        setSaved(true);
+        setCwId(savedCourseware.id);
+      }
     } catch (err) {
       console.error(err);
       setError("保存教案失败");
@@ -52,6 +58,7 @@ export default function TeacherLesson() {
       return;
     }
     try {
+      await updateCourseware(cwId, markdown);
       const blob = await downloadCoursewarePdf(cwId);
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");


### PR DESCRIPTION
## Summary
- support AI optimizing lessons in backend services
- expose `/teacher/lesson/optimize` endpoint
- add `optimizeLesson` API to frontend
- show `AI优化` button in teacher lesson page

## Testing
- `npm run lint --prefix frontend` *(fails: 20 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879b5b026ec8322814a2bf64c351fb9