### PR TITLE
Fix login first attempt issue

### DIFF
--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,5 +1,6 @@
 // src/api/auth.js
 import api from "./api";
+import axios from "axios";
 
 /**
  * 登录（OAuth2 Password 模式）
@@ -10,11 +11,15 @@ export async function login({ username, password }) {
   const params = new URLSearchParams();
   params.append("username", username);
   params.append("password", password);
+  params.append("grant_type", "password");
 
-  const resp = await api.post(
+  const resp = await axios.post(
     "/auth/token",
     params,
-    { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
+    {
+      baseURL: api.defaults.baseURL,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    }
   );
   // resp.data = { access_token, token_type, role }
   return resp.data;


### PR DESCRIPTION
## Summary
- ensure login API doesn't reuse intercepted instance
- explicitly pass `grant_type=password` when requesting a token

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a52e26bcc83229ebb7683c9e1a300