### PR TITLE
Update admin docs UI

### DIFF
--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -31,7 +31,7 @@ export default function AdminLayout() {
         <div style={{ marginBottom: '1rem' }}>您好，管理员{username}</div>
         <button className="button" onClick={() => nav('/admin/users')}>用户管理</button>
         <button className="button" onClick={() => nav('/admin/coursewares')}>课件管理</button>
-        <button className="button" onClick={() => nav('/admin/public_docs')}>公共课件管理</button>
+        <button className="button" onClick={() => nav('/admin/public_docs')}>公共资料库</button>
         <button className="button" onClick={() => nav('/admin/dashboard')}>数据概览</button>
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>

--- a/frontend/src/pages/AdminPublicDocs.jsx
+++ b/frontend/src/pages/AdminPublicDocs.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import {
   uploadPublicDoc,
   fetchPublicDocs,
@@ -11,6 +11,8 @@ export default function AdminPublicDocs() {
   const [list, setList] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const fileRef = useRef(null);
+  const [uploading, setUploading] = useState(false);
 
   const load = async () => {
     setLoading(true);
@@ -30,16 +32,32 @@ export default function AdminPublicDocs() {
     load();
   }, []);
 
-  const handleUpload = async (e) => {
-    const file = e.target.files[0];
+  const handleFiles = async (files) => {
+    const file = files[0];
     if (!file) return;
     try {
+      setUploading(true);
       await uploadPublicDoc(file);
+      setUploading(false);
       load();
     } catch (err) {
       console.error(err);
       alert('上传失败');
+      setUploading(false);
     }
+  };
+
+  const openFileDialog = () => {
+    fileRef.current && fileRef.current.click();
+  };
+
+  const handleInputChange = (e) => {
+    handleFiles(e.target.files);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
   };
 
   const handleDelete = async (id) => {
@@ -56,9 +74,27 @@ export default function AdminPublicDocs() {
   return (
     <div className="container">
       <div className="card">
-        <h2>公共课件管理</h2>
-        <div style={{ marginBottom: '1rem' }}>
-          <input type="file" onChange={handleUpload} />
+        <h2>公共资料库</h2>
+        <div
+          className="upload-dropzone"
+          onDrop={handleDrop}
+          onDragOver={(e) => e.preventDefault()}
+          onClick={openFileDialog}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') openFileDialog();
+          }}
+        >
+          <input
+            type="file"
+            ref={fileRef}
+            onChange={handleInputChange}
+            style={{ display: 'none' }}
+          />
+          <div className="upload-icon">⬆️</div>
+          <p>拖拽文件到此处或点击上传</p>
+          {uploading && <div>上传中...</div>}
         </div>
         {error && <div className="error">{error}</div>}
         {loading ? (
@@ -77,8 +113,15 @@ export default function AdminPublicDocs() {
                 <tr key={d.id}>
                   <td>{d.filename}</td>
                   <td>{formatDateTime(d.uploaded_at)}</td>
-                  <td>
-                    <button className="button" onClick={() => handleDelete(d.id)}>删除</button>
+                  <td className="actions-cell">
+                    <button
+                      className="icon-button tooltip"
+                      onClick={() => handleDelete(d.id)}
+                      aria-label="删除"
+                    >
+                      🗑️
+                      <span className="tooltip-text">删除</span>
+                    </button>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- rename admin doc page to 公共资料库
- match teacher's style for uploading and listing docs
- update sidebar button label

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a5f8814088322b90a328be916f7c6