### PR TITLE
Display dashboard stats in cards

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -756,3 +756,20 @@ table tr:hover {
   margin: 0.5rem 0 1rem;
   font-weight: bold;
 }
+
+/* Dashboard layout */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+.stat-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -27,19 +27,44 @@ export default function AdminDashboard() {
   }
   return (
     <div className="container">
-      <div className="card">
-        <h2>数据概览</h2>
-        <ul>
-          <li>教师数量: {data.teacher_count}</li>
-          <li>学生数量: {data.student_count}</li>
-          <li>课件数量: {data.courseware_count}</li>
-          <li>练习数量: {data.exercise_count}</li>
-          <li>教师今日使用次数: {data.teacher_usage_today}</li>
-          <li>学生今日使用次数: {data.student_usage_today}</li>
-          <li>教师本周使用次数: {data.teacher_usage_week}</li>
-          <li>学生本周使用次数: {data.student_usage_week}</li>
-          <li>教学效率指数(秒): {data.teaching_efficiency.toFixed ? data.teaching_efficiency.toFixed(2) : data.teaching_efficiency}</li>
-        </ul>
+      <h2>数据概览</h2>
+      <div className="dashboard-grid">
+        <div className="stat-card">
+          <div>教师数量</div>
+          <div>{data.teacher_count}</div>
+        </div>
+        <div className="stat-card">
+          <div>学生数量</div>
+          <div>{data.student_count}</div>
+        </div>
+        <div className="stat-card">
+          <div>课件数量</div>
+          <div>{data.courseware_count}</div>
+        </div>
+        <div className="stat-card">
+          <div>练习数量</div>
+          <div>{data.exercise_count}</div>
+        </div>
+        <div className="stat-card">
+          <div>教师今日使用次数</div>
+          <div>{data.teacher_usage_today}</div>
+        </div>
+        <div className="stat-card">
+          <div>学生今日使用次数</div>
+          <div>{data.student_usage_today}</div>
+        </div>
+        <div className="stat-card">
+          <div>教师本周使用次数</div>
+          <div>{data.teacher_usage_week}</div>
+        </div>
+        <div className="stat-card">
+          <div>学生本周使用次数</div>
+          <div>{data.student_usage_week}</div>
+        </div>
+        <div className="stat-card">
+          <div>教学效率指数(秒)</div>
+          <div>{data.teaching_efficiency.toFixed ? data.teaching_efficiency.toFixed(2) : data.teaching_efficiency}</div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- style admin dashboard with grid layout for metric cards
- show each metric in its own dashboard card for clarity

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5d75db3483228fe1eaeb0fb9b3b0