### PR TITLE
Unify Chakra pages with app layout

### DIFF
--- a/frontend/src/pages/ClassManagementPage.jsx
+++ b/frontend/src/pages/ClassManagementPage.jsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { ViewIcon } from '@chakra-ui/icons';
 import { fetchTeacherClasses, createClass } from '../api/teacher';
+import '../index.css';
 
 const subjects = ['语文','数学','英语','物理','化学','地理','生物','历史','政治'];
 
@@ -73,7 +74,8 @@ export default function ClassManagementPage() {
   const paged = filtered.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <Box p={4} maxW="960px" mx="auto">
+    <div className="container">
+      <Box className="card">
       <Flex justify="space-between" align="center" mb={4} flexWrap="wrap" gap={2}>
         <Heading size="lg">班级管理</Heading>
         <Button onClick={() => setShowForm(!showForm)} colorScheme="teal" size="sm">
@@ -156,6 +158,7 @@ export default function ClassManagementPage() {
           下一页
         </Button>
       </Flex>
-    </Box>
+      </Box>
+    </div>
   );
 }

--- a/frontend/src/pages/MyClassesPage.jsx
+++ b/frontend/src/pages/MyClassesPage.jsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react';
 import { ViewIcon } from '@chakra-ui/icons';
 import { fetchMyClasses, joinClass } from '../api/student';
+import '../index.css';
 
 export default function MyClassesPage() {
   const [list, setList] = useState([]);
@@ -53,7 +54,8 @@ export default function MyClassesPage() {
   };
 
   return (
-    <Box p={4} maxW="960px" mx="auto">
+    <div className="container">
+      <Box className="card">
       <Flex justify="space-between" align="center" mb={4} flexWrap="wrap" gap={2}>
         <Heading size="lg">我的班级</Heading>
         <Button size="sm" colorScheme="teal" onClick={() => setShowJoin(!showJoin)}>
@@ -110,6 +112,7 @@ export default function MyClassesPage() {
           ))}
         </SimpleGrid>
       )}
-    </Box>
+      </Box>
+    </div>
   );
 }

--- a/frontend/src/pages/StudentClassDetailPage.jsx
+++ b/frontend/src/pages/StudentClassDetailPage.jsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { ArrowBackIcon } from '@chakra-ui/icons';
 import { fetchStudentClass, leaveClass } from '../api/student';
+import '../index.css';
 
 export default function StudentClassDetailPage() {
   const { cid } = useParams();
@@ -37,11 +38,16 @@ export default function StudentClassDetailPage() {
   }, [cid]);
 
   if (!info) {
-    return <Text p={4}>加载中...</Text>;
+    return (
+      <div className="container">
+        <div className="card">加载中...</div>
+      </div>
+    );
   }
 
   return (
-    <Box p={4} pb={20} maxW="960px" mx="auto">
+    <div className="container">
+      <Box className="card" pb={20}>
       <Breadcrumb mb={4} fontSize="sm">
         <BreadcrumbItem>
           <BreadcrumbLink onClick={() => navigate('/student/homeworks')}>首页</BreadcrumbLink>
@@ -81,6 +87,7 @@ export default function StudentClassDetailPage() {
           退出班级
         </Button>
       </Flex>
-    </Box>
+      </Box>
+    </div>
   );
 }

--- a/frontend/src/pages/TeacherClassDetailPage.jsx
+++ b/frontend/src/pages/TeacherClassDetailPage.jsx
@@ -27,6 +27,7 @@ import {
 } from '@chakra-ui/react';
 import { ViewIcon, DeleteIcon, ArrowBackIcon, EditIcon, EmailIcon } from '@chakra-ui/icons';
 import { fetchTeacherClass, removeStudent, deleteClass } from '../api/teacher';
+import '../index.css';
 
 export default function TeacherClassDetailPage() {
   const { cid } = useParams();
@@ -72,7 +73,11 @@ export default function TeacherClassDetailPage() {
   };
 
   if (!info) {
-    return <Text p={4}>加载中...</Text>;
+    return (
+      <div className="container">
+        <div className="card">加载中...</div>
+      </div>
+    );
   }
 
   const students = info.students
@@ -82,7 +87,8 @@ export default function TeacherClassDetailPage() {
     );
 
   return (
-    <Box p={4} pb={20} maxW="960px" mx="auto">
+    <div className="container">
+      <Box className="card" pb={20}>
       <Breadcrumb mb={4} fontSize="sm">
         <BreadcrumbItem>
           <BreadcrumbLink onClick={() => navigate('/teacher/lesson')}>首页</BreadcrumbLink>
@@ -211,6 +217,7 @@ export default function TeacherClassDetailPage() {
           编辑信息
         </Button>
       </Flex>
-    </Box>
+      </Box>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap Chakra UI pages with the shared `container`/`card` layout
- import base CSS on Chakra UI pages

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a6f28bfcc832283f2b5ef5dd0941e