### PR TITLE
Add deletion feature for teacher lessons and exercises

### DIFF
--- a/backend/routers/exercise_router.py
+++ b/backend/routers/exercise_router.py
@@ -9,10 +9,18 @@ from pydantic import BaseModel
 from backend.schemas.exercise_schema import GenerateExerciseRequest, ExercisePreviewOut, ExerciseOut
 from backend.schemas.homework_schema import HomeworkOut
 from backend.services.exercise_service import (
-    preview_exercise, save_exercise, save_and_assign_exercise,
-    get_exercise, get_homework, list_exercises,
-    download_questions_pdf, download_answers_pdf,
-    assign_homework, stats_for_exercise, render_exercise_pdf
+    preview_exercise,
+    save_exercise,
+    save_and_assign_exercise,
+    get_exercise,
+    get_homework,
+    list_exercises,
+    download_questions_pdf,
+    download_answers_pdf,
+    assign_homework,
+    stats_for_exercise,
+    render_exercise_pdf,
+    delete_exercise,
 )
 from backend.auth import get_current_user
 from backend.models import User
@@ -139,3 +147,14 @@ def api_stats(ex_id: int, user: User = Depends(get_current_user)):
     if not ex or ex.teacher_id != user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="无权查看")
     return stats_for_exercise(ex_id)
+
+
+@router.delete("/{ex_id}")
+def api_delete(ex_id: int, user: User = Depends(get_current_user)):
+    if user.role.name != "teacher":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师访问")
+    ex = get_exercise(ex_id)
+    if not ex or ex.teacher_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="未找到练习")
+    delete_exercise(ex_id)
+    return {"status": "ok"}

--- a/backend/routers/lesson_router.py
+++ b/backend/routers/lesson_router.py
@@ -310,3 +310,19 @@ def update_courseware(
     session.commit()
     _generate_and_store_pdf(cw.id, cw.markdown)
     return CoursewareMeta(id=cw.id, topic=cw.topic, created_at=cw.created_at)
+
+
+@router.delete("/{cw_id}")
+def delete_courseware(
+    cw_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    if not current_user.role or current_user.role.name != "teacher":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="仅限教师角色访问")
+    cw = session.get(Courseware, cw_id)
+    if not cw or cw.teacher_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="课件不存在")
+    session.delete(cw)
+    session.commit()
+    return {"status": "ok"}

--- a/frontend/src/api/teacher.js
+++ b/frontend/src/api/teacher.js
@@ -208,6 +208,10 @@ export async function downloadAnswersPdf(exId) {
   return resp.data;
 }
 
+export async function deleteExercise(exId) {
+  await api.delete(`/teacher/exercise/${exId}`);
+}
+
 // src/api/teacher.js
 
 /**
@@ -238,6 +242,10 @@ export async function fetchLessonPreview(cw_id) {
 export async function updateCourseware(cw_id, markdown) {
   const resp = await api.post(`/teacher/lesson/update/${cw_id}`, { markdown });
   return resp.data;
+}
+
+export async function deleteCourseware(cw_id) {
+  await api.delete(`/teacher/lesson/${cw_id}`);
 }
 
 /** 列出所有学生 */

--- a/frontend/src/pages/ExerciseList.jsx
+++ b/frontend/src/pages/ExerciseList.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { fetchExerciseList } from "../api/teacher";
+import { fetchExerciseList, deleteExercise } from "../api/teacher";
 import { formatDateTime } from "../utils";
 import "../index.css";
 
@@ -26,6 +26,17 @@ export default function ExerciseList() {
     load();
   }, []);
 
+  const handleDelete = async (id) => {
+    if (!window.confirm('确定删除?')) return;
+    try {
+      await deleteExercise(id);
+      setList(list.filter((e) => e.id !== id));
+    } catch (err) {
+      console.error(err);
+      setError('删除失败');
+    }
+  };
+
   return (
     <div className="container">
       <div className="card">
@@ -47,8 +58,15 @@ export default function ExerciseList() {
                 <tr key={ex.id}>
                   <td>{ex.subject}</td>
                   <td>{formatDateTime(ex.created_at)}</td>
-                  <td>
+                  <td className="actions-cell">
                     <Link to={`/teacher/exercise/preview/${ex.id}`}>预览</Link>
+                    <button
+                      className="icon-button tooltip"
+                      onClick={() => handleDelete(ex.id)}
+                      aria-label="删除"
+                    >
+                      🗑️<span className="tooltip-text">删除</span>
+                    </button>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/pages/LessonList.jsx
+++ b/frontend/src/pages/LessonList.jsx
@@ -1,7 +1,7 @@
 // src/pages/LessonList.jsx
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { fetchLessonList } from "../api/teacher";
+import { fetchLessonList, deleteCourseware } from "../api/teacher";
 import { formatDateTime } from "../utils";
 import "../index.css";
 
@@ -27,6 +27,17 @@ export default function LessonList() {
     loadLessons();
   }, []);
 
+  const handleDelete = async (id) => {
+    if (!window.confirm('确定删除?')) return;
+    try {
+      await deleteCourseware(id);
+      setLessons(lessons.filter((l) => l.id !== id));
+    } catch (err) {
+      console.error(err);
+      setError('删除失败');
+    }
+  };
+
   return (
     <div className="container">
       <div className="card">
@@ -48,10 +59,15 @@ export default function LessonList() {
                 <tr key={lesson.id}>
                   <td>{lesson.topic}</td>
                   <td>{formatDateTime(lesson.created_at)}</td>
-                  <td>
-                    <Link to={`/teacher/lesson/preview/${lesson.id}`}>
-                      预览
-                    </Link>
+                  <td className="actions-cell">
+                    <Link to={`/teacher/lesson/preview/${lesson.id}`}>预览</Link>
+                    <button
+                      className="icon-button tooltip"
+                      onClick={() => handleDelete(lesson.id)}
+                      aria-label="删除"
+                    >
+                      🗑️<span className="tooltip-text">删除</span>
+                    </button>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- add delete_exercise service and router endpoints for deleting exercises
- add delete endpoint in lesson router
- expose delete APIs to frontend
- show delete buttons in lesson and exercise lists

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b1dcf3cc883229ef12b349ae1b60b