### PR TITLE
Adjust exercise card layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -719,16 +719,18 @@ table tr:hover {
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
 }
 
+
+/* 练习题量配置卡片布局 */
 .question-config-grid {
   display: flex;
-  flex-wrap: wrap;      /* 允许换行 */
-  gap: 1rem;            /* 卡片之间的间距 */
-  justify-content: flex-start; /* 左对齐，右侧留空 */
+  justify-content: center; /* 每行居中 */
+  gap: 1rem;               /* 卡片之间的间距 */
+  margin-bottom: 1rem;     /* 行间距 */
 }
 
 /* 如果你想显式给每个卡片一个固定宽度，确保它不会被压缩或撑大 */
 .question-config-card {
-  flex: 0 0 200px;      /* 0: 不放大; 0: 不收缩; 200px: 固定基础宽度 */
+  flex: 0 0 180px;      /* 固定宽度，避免压缩或拉伸 */
   background: #fff;
   padding: 1rem;
   border-radius: 8px;

--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -202,39 +202,45 @@ export default function ExercisePage() {
           />
         </div>
 
-        <div className="card">
-          <h2>配置题量</h2>
-          <div className="question-config-grid">
-            {[
+          <div className="card">
+            <h2>配置题量</h2>
+          {[
+            [
               { label: "单选题", numKey: "num_single_choice", scoreKey: "score_single_choice" },
               { label: "多选题", numKey: "num_multiple_choice", scoreKey: "score_multiple_choice" },
               { label: "填空题", numKey: "num_fill_blank", scoreKey: "score_fill_blank" },
+            ],
+            [
               { label: "简答题", numKey: "num_short_answer", scoreKey: "score_short_answer" },
               { label: "编程题", numKey: "num_programming", scoreKey: "score_programming" },
-            ].map(({ label, numKey, scoreKey }) => (
-              <div className="question-config-card" key={numKey}>
-                <h4>{label}</h4>
-                <div className="config-row">
-                  <span>数量</span>
-                  <Stepper
-                    value={form[numKey]}
-                    onChange={(v) => setForm((p) => ({ ...p, [numKey]: v }))}
-                    min={0}
-                    max={20}
-                  />
+            ],
+          ].map((group, idx) => (
+            <div className="question-config-grid" key={idx}>
+              {group.map(({ label, numKey, scoreKey }) => (
+                <div className="question-config-card" key={numKey}>
+                  <h4>{label}</h4>
+                  <div className="config-row">
+                    <span>数量</span>
+                    <Stepper
+                      value={form[numKey]}
+                      onChange={(v) => setForm((p) => ({ ...p, [numKey]: v }))}
+                      min={0}
+                      max={20}
+                    />
+                  </div>
+                  <div className="config-row">
+                    <span>分值</span>
+                    <Stepper
+                      value={form[scoreKey]}
+                      onChange={(v) => setForm((p) => ({ ...p, [scoreKey]: v }))}
+                      min={1}
+                      max={100}
+                    />
+                  </div>
                 </div>
-                <div className="config-row">
-                  <span>分值</span>
-                  <Stepper
-                    value={form[scoreKey]}
-                    onChange={(v) => setForm((p) => ({ ...p, [scoreKey]: v }))}
-                    min={1}
-                    max={100}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          ))}
 
           <div className="total-count">共计 {total} 题，总分 {totalScore}</div>
           <button className="button btn-secondary" type="submit" disabled={loading}>


### PR DESCRIPTION
## Summary
- keep first three question types on a row
- center question config cards and adjust width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d1f042b2483228b299b2a61deba8a