### PR TITLE
Fix dashboard charts

### DIFF
--- a/backend/routers/admin_router.py
+++ b/backend/routers/admin_router.py
@@ -319,7 +319,14 @@ def dashboard(current: User = Depends(get_current_user)):
             .where(LoginEvent.created_at >= today)
             .group_by(Role.name)
         ).all()
-        ratio = {r: c for r, c in ratio_rows}
+        t_active = 0
+        s_active = 0
+        for r, c in ratio_rows:
+            if r == "teacher":
+                t_active = c
+            elif r == "student":
+                s_active = c
+        ratio = {"teacher": t_active, "student": s_active}
 
         # --- Learning efficiency ---
         sub_rows = sess.exec(
@@ -386,13 +393,13 @@ def dashboard(current: User = Depends(get_current_user)):
         # --- Courseware production ---
         cw_rows = sess.exec(select(Courseware.created_at)).all()
         cw_week = {}
-        cw_month = {}
+        cw_day = {}
         for row in cw_rows:
             dt = row[0] if isinstance(row, tuple) else row
             wk = dt.strftime("%Y-%W")
-            mo = dt.strftime("%Y-%m")
+            day = dt.strftime("%Y-%m-%d")
             cw_week[wk] = cw_week.get(wk, 0) + 1
-            cw_month[mo] = cw_month.get(mo, 0) + 1
+            cw_day[day] = cw_day.get(day, 0) + 1
 
         # --- Question type distribution ---
         qtype_counts = {}
@@ -443,7 +450,7 @@ def dashboard(current: User = Depends(get_current_user)):
             "score_dist": dist,
             "mastery": mastery,
         },
-        "courseware_prod": {"week": cw_week, "month": cw_month, "qtype": qtype_counts},
+        "courseware_prod": {"week": cw_week, "day": cw_day, "qtype": qtype_counts},
         "system": {"avg_response_ms": avg_response, "error_rate": error_rate},
     }
 

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -116,14 +116,14 @@ export default function AdminDashboard() {
     ],
   };
 
-  // 课件生成 (按月)
-  const monthKeys = Object.keys(data.courseware_prod.month).sort();
-  const cwMonthData = {
-    labels: monthKeys,
+  // 课件生成 (按天)
+  const dayKeys = Object.keys(data.courseware_prod.day).sort();
+  const cwDayData = {
+    labels: dayKeys,
     datasets: [
       {
         label: '课件数',
-        data: monthKeys.map(k => data.courseware_prod.month[k]),
+        data: dayKeys.map(k => data.courseware_prod.day[k]),
         backgroundColor: 'rgba(255,99,132,0.3)',
         borderColor: 'rgba(255,99,132,1)',
         borderWidth: 2,
@@ -254,10 +254,10 @@ export default function AdminDashboard() {
 
           <div className="card chart-card">
             <div className="chart-card-header">
-              <h4>课件生成（按月）</h4>
+              <h4>课件生成（按天）</h4>
               <button className="chart-export">导出</button>
             </div>
-            <Line data={cwMonthData} options={{ plugins: { legend: { position: 'top' } } }} />
+            <Line data={cwDayData} options={{ plugins: { legend: { position: 'top' } } }} />
           </div>
 
           <div className="card chart-card">


### PR DESCRIPTION
## Summary
- ensure daily active role ratio only tracks teachers and students
- track courseware production per-day instead of per-month
- update admin dashboard to display daily courseware chart

## Testing
- `npm run lint`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dc0bbc37083229f396edef147f7a0