### PR TITLE
Unify teacher exercise previews

### DIFF
--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import Stepper from "../components/Stepper";
 
 import {
@@ -34,6 +34,24 @@ export default function ExercisePage() {
   const [assignedClasses, setAssignedClasses] = useState([]);
   const [classList, setClassList] = useState([]);
   const [showClasses, setShowClasses] = useState(false);
+
+  const grouped = useMemo(() => {
+    if (!preview) return {};
+    return preview.questions.reduce((acc, block) => {
+      const { type, items } = block;
+      if (!acc[type]) acc[type] = [];
+      acc[type].push(...items);
+      return acc;
+    }, {});
+  }, [preview]);
+
+  const typeLabels = {
+    single_choice: "单选题",
+    multiple_choice: "多选题",
+    fill_in_blank: "填空题",
+    short_answer: "简答题",
+    coding: "编程题",
+  };
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -301,14 +319,18 @@ export default function ExercisePage() {
           )}
 
           <div style={{ marginTop: "1rem" }}>
-            {preview.questions.map((block, bIdx) => (
-              <div key={bIdx} style={{ marginBottom: "1rem" }}>
-                <strong>{block.type}</strong>
-                {block.items.map((item, i) => (
-                  <div key={i} style={{ marginLeft: "1rem" }}>
+            {Object.entries(grouped).map(([type, items]) => (
+              <div key={type} style={{ marginBottom: "2rem" }}>
+                <h3>{typeLabels[type] || type}</h3>
+                {items.map((item, idx) => (
+                  <div
+                    key={item.id ?? idx}
+                    style={{ margin: "0.5rem 0 1rem 1rem" }}
+                  >
+                    <strong>{idx + 1}. </strong>
                     {item.question}
-                    {item.options && (
-                      <ul>
+                    {item.options && item.options.length > 0 && (
+                      <ul style={{ marginTop: "0.5rem" }}>
                         {item.options.map((opt, j) => (
                           <li key={j}>{opt}</li>
                         ))}


### PR DESCRIPTION
## Summary
- use `useMemo` for grouping preview questions in ExercisePage
- show generated exercise preview using the same grouped layout as the main preview page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e321264848322a5aad825a26f5b11