### PR TITLE
Show teacher username in admin courseware list

### DIFF
--- a/frontend/src/pages/AdminCoursewares.jsx
+++ b/frontend/src/pages/AdminCoursewares.jsx
@@ -98,7 +98,7 @@ export default function AdminCoursewares() {
                   <tr key={c.id}>
                     <td>{c.id}</td>
                     <td>{c.topic}</td>
-                    <td>{c.teacher_id}</td>
+                    <td>{c.teacher_username}</td>
                     <td>{formatDateTime(c.created_at)}</td>
                     <td>
                       <div className="action-buttons">


### PR DESCRIPTION
## Summary
- update `CoursewareMeta` and `CoursewarePreview` to include `teacher_username`
- join teacher info when listing coursewares
- include teacher username when previewing or updating courseware
- display teacher username in admin courseware table

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e328ef1a08322977062ba254f8aa9