### PR TITLE
Add metrics to admin dashboard

### DIFF
--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -45,6 +45,31 @@ export async function fetchDashboard() {
   return resp.data;
 }
 
+export async function fetchRealTimeOnline() {
+  const resp = await api.get('/admin/real_time_online');
+  return resp.data;
+}
+
+export async function fetchParticipationRates() {
+  const resp = await api.get('/admin/participation_rates');
+  return resp.data;
+}
+
+export async function fetchPerformanceMetrics() {
+  const resp = await api.get('/admin/performance_metrics');
+  return resp.data;
+}
+
+export async function fetchTeacherStats() {
+  const resp = await api.get('/admin/teacher_stats');
+  return resp.data;
+}
+
+export async function fetchNewCourseTrend() {
+  const resp = await api.get('/admin/new_course_trend');
+  return resp.data;
+}
+
 // ----- Public document management -----
 export async function uploadPublicDoc(file) {
   const form = new FormData();

--- a/frontend/src/ui/AdminDashboard.css
+++ b/frontend/src/ui/AdminDashboard.css
@@ -73,8 +73,9 @@
   gap: 1rem;
 }
 .overview-card {
-  flex: 1 1 calc(33.333% - 1rem);
+  flex: 1 1 calc(25% - 1rem);
   text-align: center;
+  word-break: break-all;
 }
 .overview-card h4 {
   margin-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- add new backend endpoints for KPI metrics
- expand admin API with new fetch functions
- enhance AdminDashboard with more KPI cards and new chart
- remove role ratio chart and update layout styles

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef93a6d288322ac33132a5973ab2d