### PR TITLE
Improve class distribution chart

### DIFF
--- a/backend/routers/admin_router.py
+++ b/backend/routers/admin_router.py
@@ -580,14 +580,14 @@ def teacher_stats(current: User = Depends(get_current_user)):
         ex_count = sess.exec(select(func.count()).select_from(Exercise)).one()
         class_count = sess.exec(select(func.count()).select_from(Class)).one()
 
-        dist_rows = (
-            sess.exec(
-                select(Class.name, func.count(ClassStudent.student_id))
-                .join(ClassStudent, ClassStudent.class_id == Class.id, isouter=True)
-                .group_by(Class.id)
-            ).all()
-        )
-        distribution = {name: count for name, count in dist_rows}
+        class_rows = sess.exec(select(Class.subject, Class.name).order_by(Class.subject)).all()
+        subj_map = {}
+        for subject, name in class_rows:
+            subj_map.setdefault(subject, []).append(name)
+        distribution = {
+            subj: {"count": len(names), "classes": names}
+            for subj, names in subj_map.items()
+        }
 
     return {
         "teacherCount": teacher_count,

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -152,6 +152,32 @@ export default function AdminDashboard() {
     }],
   };
 
+  const subjectLabels = Object.keys(stats.classDistribution);
+  const classDistData = {
+    labels: subjectLabels,
+    datasets: [{
+      data: subjectLabels.map(s => stats.classDistribution[s].count),
+      backgroundColor: [
+        '#FF6384','#36A2EB','#FFCE56','#4BC0C0',
+        '#9966FF','#F67019','#F53794','#B234AB'
+      ],
+      hoverOffset: 4,
+    }],
+  };
+  const classDistOptions = {
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: ctx => {
+            const label = ctx.label || '';
+            const names = stats.classDistribution[label].classes.join(', ');
+            return `${label}: ${ctx.parsed}个班级\n${names}`;
+          },
+        },
+      },
+    },
+  };
+
   return (
     <div className="dashboard-container">
       <div className="dashboard">
@@ -270,13 +296,9 @@ export default function AdminDashboard() {
                 <h4>班级数量</h4>
                 <p>{stats.classCount}</p>
               </div>
-              <div className="card overview-card">
+              <div className="card overview-card class-chart-card">
                 <h4>班级分布</h4>
-                <p>
-                  {Object.entries(stats.classDistribution)
-                    .map(([k, v]) => `${k}:${v}`)
-                    .join(' ')}
-                </p>
+                <Pie data={classDistData} options={classDistOptions} />
               </div>
             </div>
           </div>

--- a/frontend/src/ui/AdminDashboard.css
+++ b/frontend/src/ui/AdminDashboard.css
@@ -174,9 +174,13 @@ body, .dashboard {
   color: var(--color-text);
 }
 
-/* 特殊：班级分布宽卡占满 */
-.structure-group .overview-card:nth-child(2) {
-  flex: 1 1 100%;
+/* 组织结构卡片并排显示 */
+.structure-group .overview-card {
+  flex: 1 1 calc(50% - 1rem);
+}
+
+.class-chart-card canvas {
+  max-height: 200px;
 }
 
 /* 图表区域 */


### PR DESCRIPTION
## Summary
- add subject distribution details in `teacher_stats`
- show class distribution as a pie chart
- align organization cards side by side

## Testing
- `pytest -q --maxfail=1`
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_687f05c30a88832298e67e8115ecbc38