### PR TITLE
Improve Admin Dashboard metrics and layout

### DIFF
--- a/backend/routers/admin_router.py
+++ b/backend/routers/admin_router.py
@@ -306,6 +306,9 @@ def dashboard(current: User = Depends(get_current_user)):
         ).one()
         cw_count = sess.exec(select(func.count()).select_from(Courseware)).one()
         ex_count = sess.exec(select(func.count()).select_from(Exercise)).one()
+        public_doc_count = sess.exec(
+            select(func.count()).select_from(Document).where(Document.is_public == True)
+        ).one()
 
         # --- User activity metrics ---
         daily_rows = sess.exec(
@@ -469,6 +472,7 @@ def dashboard(current: User = Depends(get_current_user)):
             "student": student_count,
             "courseware": cw_count,
             "exercise": ex_count,
+            "public_doc": public_doc_count,
         },
         "activity": {
             "trend": trend_list,
@@ -521,12 +525,11 @@ def participation_rates(current: User = Depends(get_current_user)):
 
     with Session(engine) as sess:
         hw_total = sess.exec(select(func.count()).select_from(Homework)).one()
-        sub_total = sess.exec(
-            select(func.count())
-            .select_from(Submission)
+        completed_hw = sess.exec(
+            select(func.count(func.distinct(Submission.homework_id)))
             .where(Submission.status == "completed")
         ).one()
-        assignment_rate = sub_total / hw_total if hw_total else 0
+        completion_rate = completed_hw / hw_total if hw_total else 0
 
         student_count = sess.exec(
             select(func.count()).select_from(User).join(Role).where(Role.name == "student")
@@ -534,11 +537,11 @@ def participation_rates(current: User = Depends(get_current_user)):
         practice_students = sess.exec(
             select(func.count(func.distinct(Practice.student_id)))
         ).one()
-        exercise_rate = practice_students / student_count if student_count else 0
+        usage_rate = practice_students / student_count if student_count else 0
 
     return {
-        "assignmentParticipationRate": assignment_rate,
-        "exerciseParticipationRate": exercise_rate,
+        "assignmentCompletionRate": completion_rate,
+        "practiceUsageRate": usage_rate,
     }
 
 

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -232,6 +232,10 @@ export default function AdminDashboard() {
                 <h4>练习数量</h4>
                 <p>{data.counts.exercise}</p>
               </div>
+              <div className="card overview-card">
+                <h4>公共资料数</h4>
+                <p>{data.counts.public_doc}</p>
+              </div>
             </div>
           </div>
 
@@ -278,12 +282,12 @@ export default function AdminDashboard() {
             <h3 className="group-title">参与度</h3>
             <div className="group-cards">
               <div className="card overview-card">
-                <h4>作业参与率</h4>
-                <p>{(participation.assignmentParticipationRate * 100).toFixed(1)}%</p>
+                <h4>作业完成率</h4>
+                <p>{(participation.assignmentCompletionRate * 100).toFixed(1)}%</p>
               </div>
               <div className="card overview-card">
-                <h4>练习参与率</h4>
-                <p>{(participation.exerciseParticipationRate * 100).toFixed(1)}%</p>
+                <h4>随练使用率</h4>
+                <p>{(participation.practiceUsageRate * 100).toFixed(1)}%</p>
               </div>
             </div>
           </div>

--- a/frontend/src/ui/AdminDashboard.css
+++ b/frontend/src/ui/AdminDashboard.css
@@ -148,6 +148,10 @@ body, .dashboard {
   overflow: hidden;
   transition: transform 0.2s, box-shadow 0.2s;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 .overview-card::before {
   content: '';
@@ -183,6 +187,11 @@ body, .dashboard {
   max-height: 200px;
 }
 
+.chart-card canvas,
+.overview-card canvas {
+  margin: 0 auto;
+}
+
 /* 图表区域 */
 .charts-section .charts-grid {
   display: grid;
@@ -195,6 +204,9 @@ body, .dashboard {
   box-shadow: 0 4px 12px var(--shadow-light);
   padding: 1rem;
   transition: box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .chart-card:hover {
   box-shadow: 0 8px 20px var(--shadow-hover);
@@ -204,6 +216,7 @@ body, .dashboard {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.75rem;
+  width: 100%;
 }
 .chart-card-header h4 {
   margin: 0;


### PR DESCRIPTION
## Summary
- show new "公共资料数" metric for admins
- rename participation metrics with new logic
- keep card layouts centered for consistency

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile backend/routers/admin_router.py`

------
https://chatgpt.com/codex/tasks/task_e_687f0a589d648322acddb5ab30af7db8