### PR TITLE
Update self practice preview UI

### DIFF
--- a/frontend/src/pages/EvaluateAssistant.jsx
+++ b/frontend/src/pages/EvaluateAssistant.jsx
@@ -21,6 +21,14 @@ export default function EvaluateAssistant() {
   const [error, setError] = useState("");
   const navigate = useNavigate();
 
+  const typeLabels = {
+    single_choice: "单选题",
+    multiple_choice: "多选题",
+    fill_in_blank: "填空题",
+    short_answer: "简答题",
+    coding: "编程题",
+  };
+
   useEffect(() => {
     const load = async () => {
       setAnalysis("");
@@ -178,7 +186,7 @@ export default function EvaluateAssistant() {
                 className="eval-preview-block"
                 style={{ marginBottom: "1rem" }}
               >
-                <strong>{block.type}</strong>
+                <strong>{typeLabels[block.type] || block.type}</strong>
                 {block.items.map((item, i) => (
                   <div
                     key={i}

--- a/frontend/src/pages/SelfPracticeDetail.jsx
+++ b/frontend/src/pages/SelfPracticeDetail.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { getSelfPractice, downloadSelfPracticePdf, fetchStudentAnalysis } from "../api/student";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { getSelfPractice, downloadSelfPracticePdf } from "../api/student";
 import "../index.css";
 
 export default function SelfPracticeDetail() {
@@ -11,8 +9,14 @@ export default function SelfPracticeDetail() {
   const [practice, setPractice] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [analysis, setAnalysis] = useState("");
-  const [analysisLoading, setAnalysisLoading] = useState(false);
+
+  const typeLabels = {
+    single_choice: "单选题",
+    multiple_choice: "多选题",
+    fill_in_blank: "填空题",
+    short_answer: "简答题",
+    coding: "编程题",
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -31,20 +35,6 @@ export default function SelfPracticeDetail() {
     load();
   }, [id]);
 
-  useEffect(() => {
-    const load = async () => {
-      setAnalysisLoading(true);
-      try {
-        const data = await fetchStudentAnalysis();
-        setAnalysis(data.analysis);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setAnalysisLoading(false);
-      }
-    };
-    load();
-  }, []);
 
   const handleDownload = async () => {
     const blob = await downloadSelfPracticePdf(id);
@@ -69,11 +59,6 @@ export default function SelfPracticeDetail() {
           返回
         </button>
         <h2>随练预览</h2>
-        <div className="markdown-preview" style={{ minHeight: '4rem' }}>
-          {analysisLoading ? '正在分析...' : (
-            <ReactMarkdown children={analysis} remarkPlugins={[remarkGfm]} />
-          )}
-        </div>
         {error && <div className="error">{error}</div>}
         {loading ? (
           <div>加载中...</div>
@@ -88,7 +73,7 @@ export default function SelfPracticeDetail() {
               <div style={{ marginTop: "1rem" }}>
                 {(practice.questions || []).map((block, bIdx) => (
                   <div key={bIdx} style={{ marginBottom: "1rem" }}>
-                    <strong>{block.type}</strong>
+                    <strong>{typeLabels[block.type] || block.type}</strong>
                     {(block.items || []).map((item, i) => (
                       <div key={i} style={{ marginLeft: "1rem" }}>
                         {item.question}


### PR DESCRIPTION
## Summary
- show Chinese labels for question types when generating self practices
- show Chinese labels for question types in self practice preview page
- remove learning analysis content from self practice preview

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f0eb91a6c8322a0e99c4086948112