### PR TITLE
UI tweaks for teacher/admin pages

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -288,6 +288,23 @@ table tr:hover {
   background: #f0f0f0;
 }
 
+/* Admin user management delete button */
+.admin-action-btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background 0.2s;
+}
+.admin-delete-btn {
+  background: linear-gradient(90deg, #e74c3c, #c0392b);
+  color: #fff;
+}
+.admin-delete-btn:hover {
+  background: #c0392b;
+}
+
 @keyframes fade-in {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -81,7 +81,10 @@ export default function AdminUsers() {
                   <td>{u.username}</td>
                   <td>{u.role}</td>
                   <td>
-                    <button className="button" onClick={() => handleDelete(u.id)}>
+                    <button
+                      className="admin-action-btn admin-delete-btn"
+                      onClick={() => handleDelete(u.id)}
+                    >
                       删除
                     </button>
                   </td>

--- a/frontend/src/pages/ExerciseList.jsx
+++ b/frontend/src/pages/ExerciseList.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { IconButton } from '@chakra-ui/react';
+import { ViewIcon } from '@chakra-ui/icons';
 import { fetchExerciseList, deleteExercise } from "../api/teacher";
 import { formatDateTime } from "../utils";
 import "../index.css";
 
 export default function ExerciseList() {
+  const navigate = useNavigate();
   const [list, setList] = useState([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
@@ -71,7 +74,13 @@ export default function ExerciseList() {
                   <td>{ex.subject}</td>
                   <td>{formatDateTime(ex.created_at)}</td>
                   <td className="actions-cell">
-                    <Link to={`/teacher/exercise/preview/${ex.id}`}>预览</Link>
+                    <IconButton
+                      size="sm"
+                      mr={1}
+                      icon={<ViewIcon />}
+                      aria-label="预览"
+                      onClick={() => navigate(`/teacher/exercise/preview/${ex.id}`)}
+                    />
                     <button
                       className="icon-button tooltip"
                       onClick={() => handleDelete(ex.id)}

--- a/frontend/src/pages/LessonList.jsx
+++ b/frontend/src/pages/LessonList.jsx
@@ -1,11 +1,14 @@
 // src/pages/LessonList.jsx
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { IconButton } from '@chakra-ui/react';
+import { ViewIcon } from '@chakra-ui/icons';
 import { fetchLessonList, deleteCourseware } from "../api/teacher";
 import { formatDateTime } from "../utils";
 import "../index.css";
 
 export default function LessonList() {
+  const navigate = useNavigate();
   const [lessons, setLessons] = useState([]);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
@@ -72,7 +75,13 @@ export default function LessonList() {
                   <td>{lesson.topic}</td>
                   <td>{formatDateTime(lesson.created_at)}</td>
                   <td className="actions-cell">
-                    <Link to={`/teacher/lesson/preview/${lesson.id}`}>预览</Link>
+                    <IconButton
+                      size="sm"
+                      mr={1}
+                      icon={<ViewIcon />}
+                      aria-label="预览"
+                      onClick={() => navigate(`/teacher/lesson/preview/${lesson.id}`)}
+                    />
                     <button
                       className="icon-button tooltip"
                       onClick={() => handleDelete(lesson.id)}


### PR DESCRIPTION
## Summary
- use eye icon for preview actions in lesson & exercise lists
- style admin user delete button similar to courseware buttons

## Testing
- `npm run lint`
- `pytest -q --disable-warnings --maxfail=1 || true`

------
https://chatgpt.com/codex/tasks/task_e_687f335010e88322a84e730560a51834