### PR TITLE
Fix admin dashboard card vertical alignment

### DIFF
--- a/frontend/src/ui/AdminDashboard.css
+++ b/frontend/src/ui/AdminDashboard.css
@@ -61,6 +61,10 @@ body, .dashboard {
   min-width: 200px;            /* 增大最小宽度 */
   min-height: 120px;           /* 增大最小高度 */
   transition: transform 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 .availability-card:hover {
   transform: translateY(-6px);
@@ -189,7 +193,7 @@ body, .dashboard {
 
 .chart-card canvas,
 .overview-card canvas {
-  margin: 0 auto;
+  margin: auto;
 }
 
 /* 图表区域 */
@@ -206,7 +210,7 @@ body, .dashboard {
   transition: box-shadow 0.2s;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch; /* keep header left aligned */
 }
 .chart-card:hover {
   box-shadow: 0 8px 20px var(--shadow-hover);
@@ -246,6 +250,10 @@ body, .dashboard {
   padding: 1rem;
   border-radius: 0.75rem;
   font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 .error-card {
   background: #FFE6E6;


### PR DESCRIPTION
## Summary
- center content vertically for dashboard small cards
- keep chart card headers left aligned while centering charts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f36e3ec108322b400e5a693050415