### PR TITLE
Fix preview card width

### DIFF
--- a/frontend/src/pages/ExercisePage.jsx
+++ b/frontend/src/pages/ExercisePage.jsx
@@ -268,7 +268,10 @@ export default function ExercisePage() {
       </form>
 
       {showPreview && preview && (
-        <div className="preview-area card" style={{ marginTop: "1rem" }}>
+        <div
+          className="preview-area card"
+          style={{ marginTop: "1rem", maxWidth: "960px" }}
+        >
           <div className="actions">
             <button
               className="button btn-secondary"

--- a/frontend/src/pages/ExercisePreview.jsx
+++ b/frontend/src/pages/ExercisePreview.jsx
@@ -118,7 +118,7 @@ export default function ExercisePreview() {
 
   return (
     <div className="container">
-      <div className="card">
+      <div className="card" style={{ maxWidth: "960px" }}>
         <button
           className="button btn-tertiary"
           style={{ width: "auto", marginBottom: "1rem" }}


### PR DESCRIPTION
## Summary
- ensure generated preview card width matches other cards
- set same max width for preview page card

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687f49493f748322973eb5712f6ad703