### PR TITLE
feat: add sse streaming for ai teacher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ backend/.env
 
 backend/storage/
 /backend/word_files
+node_modules/


### PR DESCRIPTION
## Summary
- add streaming chat service to emit tokens
- expose SSE endpoint for session chat and allow token authentication
- stream AI teacher replies on frontend using EventSource
- ignore node_modules directory

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3152e73248322872a9d4900fa0dc1