### PR TITLE
feat: enable teacher document retrieval in student AI chat

### DIFF
--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -65,8 +65,10 @@ def api_get_messages(sid: int, user: User = Depends(get_current_user)):
 
 
 @router.post("/session/{sid}/ask", response_model=MessageOut)
-def api_ask_in_session(sid: int, req: AskRequest, user: User = Depends(get_current_user)):
-    msg = ask_in_session(user.id, sid, req.question)
+def api_ask_in_session(
+    sid: int, req: AskRequest, user: User = Depends(get_current_user)
+):
+    msg = ask_in_session(user.id, sid, req.question, use_docs=req.use_docs)
     return MessageOut(id=msg.id, session_id=msg.session_id, role=msg.role, content=msg.content, created_at=msg.created_at)
 
 
@@ -84,9 +86,11 @@ def _user_from_token(token: str) -> User:
 
 
 @router.get("/session/{sid}/ask_stream")
-def api_ask_in_session_stream(sid: int, question: str, token: str):
+def api_ask_in_session_stream(
+    sid: int, question: str, token: str, use_docs: bool = False
+):
     user = _user_from_token(token)
-    gen = ask_in_session_stream(user.id, sid, question)
+    gen = ask_in_session_stream(user.id, sid, question, use_docs=use_docs)
 
     def event_gen():
         for t in gen:

--- a/backend/schemas/student_schema.py
+++ b/backend/schemas/student_schema.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 class AskRequest(BaseModel):
     question: str
+    use_docs: bool = False
 
 class ChatOut(BaseModel):
     id: int

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -16,6 +16,7 @@ export default function StudentAiTeacher() {
   const [current, setCurrent] = useState(null);
   const [messages, setMessages] = useState([]);
   const [question, setQuestion] = useState("");
+  const [useDocs, setUseDocs] = useState(false);
   const endRef = useRef(null);
 
   // 常用的“热门问题”
@@ -95,7 +96,7 @@ export default function StudentAiTeacher() {
     const base = api.defaults.baseURL || "";
     const url = `${base}/student/ai/session/${current}/ask_stream?question=${encodeURIComponent(
       q
-    )}&token=${token}`;
+    )}&token=${token}&use_docs=${useDocs}`;
     const es = new EventSource(url);
     es.onmessage = (e) => {
       const t = e.data;
@@ -197,6 +198,18 @@ export default function StudentAiTeacher() {
         {/* 温馨提示 */}
         <div className="sa-tip">
           💡 建议输入完整的问题描述以获得更精准回答。
+        </div>
+
+        {/* 检索开关 */}
+        <div className="sa-option">
+          <label>
+            <input
+              type="checkbox"
+              checked={useDocs}
+              onChange={(e) => setUseDocs(e.target.checked)}
+            />
+            使用教师资料
+          </label>
         </div>
 
         {/* 消息列表 */}

--- a/frontend/src/ui/StudentAiTeacher.css
+++ b/frontend/src/ui/StudentAiTeacher.css
@@ -100,6 +100,10 @@ body,
   color: #718096;
   margin-bottom: 1rem;
 }
+
+.sa-option {
+  margin-bottom: 0.5rem;
+}
 /* 让每条消息行撑满父容器 */
 .sa-msg {
   display: flex;


### PR DESCRIPTION
## Summary
- allow chat service to retrieve paragraphs from all teacher documents and inject as system prompt
- expose `use_docs` toggle in student chat API and front-end page
- style student chat option control

## Testing
- `pytest`
- `CI=1 npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3d63fd2788322a22ea4634a2e555b