### PR TITLE
fix: dedupe AI teacher token stream

### DIFF
--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -103,7 +103,14 @@ export default function StudentAiTeacher() {
       setMessages((prev) => {
         const msgs = [...prev];
         if (msgs[aiIndex]) {
-          msgs[aiIndex].content += t;
+          const aiMsg = msgs[aiIndex];
+          const existing = aiMsg.content;
+          const addition = t.startsWith(existing)
+            ? t.slice(existing.length)
+            : t;
+          if (addition) {
+            msgs[aiIndex] = { ...aiMsg, content: existing + addition };
+          }
         }
         return msgs;
       });


### PR DESCRIPTION
## Summary
- avoid duplicate tokens when streaming AI teacher responses in student view

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3e996e8148322829609e16400c1da