### PR TITLE
fix: keep AI teacher page fixed size

### DIFF
--- a/frontend/src/pages/StudentLayout.jsx
+++ b/frontend/src/pages/StudentLayout.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import "../ui/layout.css";
 
 export default function StudentLayout() {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const username = localStorage.getItem("username") || "";
+  const isAiPage = location.pathname.startsWith("/student/ai");
 
   const logout = () => {
     localStorage.removeItem("token");
@@ -37,7 +39,7 @@ export default function StudentLayout() {
         <div style={{ flex: 1 }} />
         <button className="button logout-btn" onClick={logout}>登出</button>
       </div>
-      <div className={`main-content${open ? " shifted" : ""}`}>
+      <div className={`main-content${open ? " shifted" : ""}${isAiPage ? " ai-page" : ""}`}>
         <Outlet />
       </div>
     </>

--- a/frontend/src/ui/StudentAiTeacher.css
+++ b/frontend/src/ui/StudentAiTeacher.css
@@ -6,7 +6,7 @@ body,
   margin: 0;
 }
 .sa-container {
-  height: 100vh; /* occupy full viewport */
+  height: 100%; /* occupy full height of parent */
   display: flex;
 }
 /* —— 主区垂直布局 —— */

--- a/frontend/src/ui/layout.css
+++ b/frontend/src/ui/layout.css
@@ -124,6 +124,13 @@ body {
   margin-left: var(--sidebar-width);        /* 240px */
 }
 
+/* 全屏无滚动的 AI 教师页面 */
+.main-content.ai-page{
+  padding: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
 /* ===== 响应式：窄屏顶栏 ===== */
 @media (max-width: 768px){
   .sidebar,


### PR DESCRIPTION
## Summary
- ensure StudentLayout marks AI page and applies fixed-height layout
- constrain AI teacher container to parent height and hide outer scroll

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe279220832296873cf5bfa6b2ea