### PR TITLE
Fix LaTeX block conversion for AI teacher messages

### DIFF
--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -53,7 +53,8 @@ export default function StudentAiTeacher() {
     if (!text) return "";
     let processed = text
       .replace(/\\\((.+?)\\\)/gs, '$$$1$$')
-      .replace(/\\\[(.+?)\\\]/gs, '$$$$1$$$$')
+      // Convert \[ ... \] to display-mode $$ ... $$
+      .replace(/\\\[(.+?)\\\]/gs, '$$$$$1$$$$')
       .replace(/(?<!\$)\$\s+([^$]*?)\s+\$(?!\$)/g, '$$$1$$')
       .replace(/\$\$([\s\S]+?)\$\$/g, (_, m) => `\n$$${m.trim()}$$\n`);
     processed = processed


### PR DESCRIPTION
## Summary
- correctly convert `\[ ... \]` LaTeX blocks to `$$ ... $$` in AI teacher messages

## Testing
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4608f9614832289480d1488266417