### PR TITLE
feat: add animated backgrounds and transitions

### DIFF
--- a/frontend/src/components/AnimatedBackground.jsx
+++ b/frontend/src/components/AnimatedBackground.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import AIEduConstellation from "../pages/AIEduConstellation";
+import "../ui/background.css";
+
+export default function AnimatedBackground() {
+  return (
+    <div className="app-bg" aria-hidden="true">
+      <div className="bg-aurora" />
+      <div className="bg-grid" />
+      <AIEduConstellation />
+      <div className="bg-dots">
+        {Array.from({ length: 14 }).map((_, i) => (
+          <span key={i} style={{ "--i": i }} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminLayout.jsx
+++ b/frontend/src/pages/AdminLayout.jsx
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useLocation } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import AnimatedBackground from "../components/AnimatedBackground";
 import "../ui/layout.css";
 
 export default function AdminLayout() {
   const [collapsed, setCollapsed] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const username = localStorage.getItem("username") || "";
+  const MotionBox = motion.div;
 
   const logout = () => {
     localStorage.removeItem("token");
@@ -68,9 +72,19 @@ export default function AdminLayout() {
       </aside>
 
       <main className={`app-main ${collapsed ? "shift-collapsed" : "shift-open"}`}>
-        <div className="page-shell">
-          <Outlet />
-        </div>
+        <AnimatedBackground />
+        <AnimatePresence mode="wait">
+          <MotionBox
+            key={location.pathname}
+            className="page-shell"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.4 }}
+          >
+            <Outlet />
+          </MotionBox>
+        </AnimatePresence>
       </main>
     </>
   );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -33,7 +33,7 @@ export default function LoginPage() {
       if (role === "teacher") navigate("/teacher");
       else if (role === "admin") navigate("/admin");
       else navigate("/student");
-    } catch (err) {
+    } catch {
       setError("用户名或密码错误");
     } finally {
       setLoading(false);

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -4,8 +4,7 @@ import { register } from "../api/auth";
 import { useNavigate, Link } from "react-router-dom";
 import "../index.css";        // 全局样式（保持）
 import "../ui/login.css";     // 复用登录页的深色与动画样式
-import AIEduConstellation from "./AIEduConstellation";
-import ShootingStars from "./ShootingStars";
+import AnimatedBackground from "../components/AnimatedBackground";
 
 export default function RegisterPage() {
   const [form, setForm] = useState({
@@ -38,18 +37,8 @@ export default function RegisterPage() {
 
   return (
     <div className="login-container">
-      {/* 动画背景层（与登录页一致） */}
-      <div className="login-bg" aria-hidden="true">
-        <div className="bg-aurora" />
-        <div className="bg-grid" />
-        <AIEduConstellation />
-        <ShootingStars count={16} speed={0.8} />
-        <div className="bg-dots">
-          {Array.from({ length: 14 }).map((_, i) => (
-            <span key={i} style={{ "--i": i }} />
-          ))}
-        </div>
-      </div>
+      {/* 动画背景层（复用登录页但不含流星） */}
+      <AnimatedBackground />
 
       {/* 注册卡片（沿用 login-card / login-input / login-button / login-link / login-error） */}
       <div className="login-card">

--- a/frontend/src/pages/StudentLayout.jsx
+++ b/frontend/src/pages/StudentLayout.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import AnimatedBackground from "../components/AnimatedBackground";
 import "../ui/layout.css";
 
 export default function StudentLayout() {
@@ -8,6 +10,7 @@ export default function StudentLayout() {
   const location = useLocation();
   const username = localStorage.getItem("username") || "";
   const isAiPage = location.pathname.startsWith("/student/ai");
+  const MotionBox = motion.div;
 
   const logout = () => {
     localStorage.removeItem("token");
@@ -76,13 +79,32 @@ export default function StudentLayout() {
 
       {/* 主内容：与 TeacherLayout 同步的位移与壳层；AI页保留全屏特性 */}
       <main className={`app-main ${collapsed ? "shift-collapsed" : "shift-open"} ${isAiPage ? "ai-page" : ""}`}>
+        <AnimatedBackground />
         {isAiPage ? (
-          // 保持 AI 页原样（不包裹外层卡片）
-          <Outlet />
+          <AnimatePresence mode="wait">
+            <MotionBox
+              key={location.pathname}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.4 }}
+            >
+              <Outlet />
+            </MotionBox>
+          </AnimatePresence>
         ) : (
-          <div className="page-shell">
-            <Outlet />
-          </div>
+          <AnimatePresence mode="wait">
+            <MotionBox
+              key={location.pathname}
+              className="page-shell"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.4 }}
+            >
+              <Outlet />
+            </MotionBox>
+          </AnimatePresence>
         )}
       </main>
     </>

--- a/frontend/src/pages/TeacherLayout.jsx
+++ b/frontend/src/pages/TeacherLayout.jsx
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useLocation } from "react-router-dom";
+import { AnimatePresence, motion } from "framer-motion";
+import AnimatedBackground from "../components/AnimatedBackground";
 import "../ui/layout.css";
 
 export default function TeacherLayout() {
   const [collapsed, setCollapsed] = useState(false);   // 仅折叠/展开
   const navigate = useNavigate();
+  const location = useLocation();
   const username = localStorage.getItem("username") || "";
+  const MotionBox = motion.div;
 
   const logout = () => {
     localStorage.removeItem("token");
@@ -79,9 +83,19 @@ export default function TeacherLayout() {
 
       {/* 主内容：仍然只渲染你的子路由 */}
       <main className={`app-main ${collapsed ? "shift-collapsed" : "shift-open"}`}>
-        <div className="page-shell">
-          <Outlet />
-        </div>
+        <AnimatedBackground />
+        <AnimatePresence mode="wait">
+          <MotionBox
+            key={location.pathname}
+            className="page-shell"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.4 }}
+          >
+            <Outlet />
+          </MotionBox>
+        </AnimatePresence>
       </main>
     </>
   );

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -9,6 +9,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";  // 引入 GitHub 风格的 Markdown 支持
 import "../index.css";  // 引用全局样式
+import "../ui/teacher-lesson.css";  // 加载生成动画样式
 
 export default function TeacherLesson() {
   const [topic, setTopic] = useState("");
@@ -121,6 +122,12 @@ export default function TeacherLesson() {
             </button>
           </div>
         </form>
+        {loading && (
+          <div className="lesson-loader">
+            <div className="rocket">🚀</div>
+            <p>AI 正在生成教案，请稍候...</p>
+          </div>
+        )}
 
         {markdown && (
           <>

--- a/frontend/src/ui/background.css
+++ b/frontend/src/ui/background.css
@@ -1,0 +1,83 @@
+.app-bg{
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  z-index:0;
+}
+
+.bg-aurora{
+  position:absolute;
+  inset:-10% -10% -10% -10%;
+  background:
+    radial-gradient(60vmax 60vmax at 20% -10%, rgba(20,184,166,.18), transparent 60%),
+    radial-gradient(50vmax 50vmax at 110% 10%, rgba(6,182,212,.16), transparent 60%),
+    radial-gradient(40vmax 40vmax at -10% 90%, rgba(56,189,248,.14), transparent 60%);
+  filter: blur(2px);
+  animation: aurora-pan 16s linear infinite;
+  opacity:.9;
+}
+@keyframes aurora-pan{
+  0%   { transform: translateX(0) translateY(0); }
+  50%  { transform: translateX(-3%) translateY(1.8%); }
+  100% { transform: translateX(0) translateY(0); }
+}
+
+.bg-grid{
+  position:absolute; inset:0;
+  background-image:
+    linear-gradient(rgba(255,255,255,.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,.06) 1px, transparent 1px);
+  background-size: 42px 42px, 42px 42px;
+  mask-image: radial-gradient(70% 60% at 50% 40%, #000 60%, transparent 100%);
+  -webkit-mask-image: radial-gradient(70% 60% at 50% 40%, #000 60%, transparent 100%);
+  animation: grid-breathe 10s ease-in-out infinite;
+  opacity:.35;
+}
+@keyframes grid-breathe{
+  0%,100% { transform: scale(1); opacity:.32; }
+  50%     { transform: scale(1.025); opacity:.45; }
+}
+
+.bg-dots{ position:absolute; inset:0; }
+.bg-dots span{
+  position:absolute;
+  width:10px; height:10px; border-radius:50%;
+  background: radial-gradient(circle at 35% 35%, #fff 10%, rgba(255,255,255,.8) 40%, rgba(255,255,255,.1) 70%, transparent 72%);
+  box-shadow:
+    0 0 18px rgba(6, 182, 212, .6),
+    0 0 42px rgba(20, 184, 166, .35);
+  opacity:.95;
+  animation:
+    dot-float calc(2s + (var(--i) * .25s)) ease-in-out infinite,
+    dot-pulse calc(1.4s + (var(--i) * .2s)) ease-in-out infinite;
+}
+@keyframes dot-float{
+  0%   { transform: translate(0px, 0px); }
+  25%  { transform: translate(-6px, -16px); }
+  50%  { transform: translate(6px, -22px); }
+  75%  { transform: translate(-4px, -12px); }
+  100% { transform: translate(0px, 0px); }
+}
+@keyframes dot-pulse{
+  0%,100% { filter: drop-shadow(0 0 10px rgba(6,182,212,.4)); opacity:.8; }
+  50%     { filter: drop-shadow(0 0 26px rgba(20,184,166,.7)); opacity:1; }
+}
+
+.bg-dots span:nth-child(1){ top:18%; left:24%; }
+.bg-dots span:nth-child(2){ top:26%; left:68%; }
+.bg-dots span:nth-child(3){ top:40%; left:14%; }
+.bg-dots span:nth-child(4){ top:44%; left:54%; }
+.bg-dots span:nth-child(5){ top:52%; left:78%; }
+.bg-dots span:nth-child(6){ top:62%; left:32%; }
+.bg-dots span:nth-child(7){ top:66%; left:58%; }
+.bg-dots span:nth-child(8){ top:72%; left:20%; }
+.bg-dots span:nth-child(9){ top:22%; left:84%; }
+.bg-dots span:nth-child(10){ top:34%; left:38%; }
+.bg-dots span:nth-child(11){ top:58%; left:12%; }
+.bg-dots span:nth-child(12){ top:76%; left:72%; }
+.bg-dots span:nth-child(13){ top:30%; left:50%; }
+.bg-dots span:nth-child(14){ top:54%; left:90%; }
+
+@media (prefers-reduced-motion: reduce){
+  .bg-aurora, .bg-grid, .bg-dots span{ animation: none !important; }
+}

--- a/frontend/src/ui/layout.css
+++ b/frontend/src/ui/layout.css
@@ -71,6 +71,7 @@ body{
   padding:0;                /* 去掉白色间隙 */
   background:var(--bg);
   color:var(--text-1);
+  position:relative;        /* 允许绝对定位的背景 */
 }
 .app-main.shift-open{ margin-left:var(--sidebar-w); }
 .app-main.shift-collapsed{ margin-left:var(--sidebar-w-collapsed); }
@@ -82,6 +83,8 @@ body{
   min-height:100vh;
   padding:24px;
   color:var(--text-1);
+  position:relative;
+  z-index:1;                /* 高于动画背景 */
 }
 
 /* ===== 响应式 ===== */

--- a/frontend/src/ui/layout.css
+++ b/frontend/src/ui/layout.css
@@ -14,7 +14,7 @@
 
 /* ===== 基础 ===== */
 *{ box-sizing: border-box; }
-html,body,#root{ height:100%; }
+html,body,#root{ height:100%; overflow:hidden; }
 body{
   margin:0;
   font-family: ui-sans-serif, system-ui, -apple-system, "PingFang SC","Microsoft YaHei",Segoe UI,Roboto,Helvetica,Arial,"Noto Sans CJK",sans-serif;
@@ -72,6 +72,7 @@ body{
   background:var(--bg);
   color:var(--text-1);
   position:relative;        /* 允许绝对定位的背景 */
+  overflow:hidden;          /* 避免背景造成的页面轻微滑动 */
 }
 .app-main.shift-open{ margin-left:var(--sidebar-w); }
 .app-main.shift-collapsed{ margin-left:var(--sidebar-w-collapsed); }
@@ -80,7 +81,8 @@ body{
 .page-shell{
   background:var(--card);
   box-shadow:var(--shadow);
-  min-height:100vh;
+  height:100vh;             /* 固定高度铺满屏幕 */
+  overflow:auto;            /* 需要时在内部滚动 */
   padding:24px;
   color:var(--text-1);
   position:relative;

--- a/frontend/src/ui/teacher-lesson.css
+++ b/frontend/src/ui/teacher-lesson.css
@@ -1,0 +1,15 @@
+.lesson-loader{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  margin-top:1.5rem;
+  color:var(--text-1);
+}
+.lesson-loader .rocket{
+  font-size:3rem;
+  animation: rocket-float .8s ease-in-out infinite alternate;
+}
+@keyframes rocket-float{
+  from{ transform: translateY(0) rotate(-10deg); }
+  to{ transform: translateY(-18px) rotate(10deg); }
+}


### PR DESCRIPTION
## Summary
- add reusable animated background component and apply it across layouts and register page
- animate page transitions with framer-motion
- show playful rocket animation while teacher lesson plan is generating

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68dc161288322aae9d73e9f28693e