### PR TITLE
feat: restore teacher lesson animation and dark headers

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -200,15 +200,19 @@ table {
   color: var(--text-1);
 }
 table, th, td { border: 1px solid var(--ring); padding: 8px; }
-th {
+thead {
+  background: rgba(22, 28, 45, 0.85) !important;
+  backdrop-filter: blur(6px);
+}
+thead th {
   text-align: left;
-  background-color: var(--slate-800);
+  background: transparent !important;
   font-weight: bold;
   color: var(--text-1);
 }
 td { text-align: left; background: var(--slate-900); }
-table tr:nth-child(even) { background-color: color-mix(in srgb, var(--slate-900) 90%, #000); }
-table tr:hover { background-color: var(--slate-800); }
+table tbody tr:nth-child(even) { background-color: color-mix(in srgb, var(--slate-900) 90%, #000); }
+table tbody tr:hover { background-color: var(--slate-800); }
 
 /* Small icon button used for history delete actions */
 .icon-button {

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -33,11 +33,11 @@ export default function LoginPage() {
       if (role === "teacher") navigate("/teacher");
       else if (role === "admin") navigate("/admin");
       else navigate("/student");
-    } catch (err) {
-      setError("用户名或密码错误");
-    } finally {
-      setLoading(false);
-    }
+      } catch {
+        setError("用户名或密码错误");
+      } finally {
+        setLoading(false);
+      }
   };
 
   return (

--- a/frontend/src/pages/TeacherLesson.jsx
+++ b/frontend/src/pages/TeacherLesson.jsx
@@ -10,6 +10,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import "../index.css";            // 全局样式
 import "../ui/teacher-lesson.css"; // 本页样式（含 .tl-loading 居中覆盖）
+import ShootingStars from "./ShootingStars";
 
 export default function TeacherLesson() {
   const [topic, setTopic] = useState("");
@@ -93,6 +94,7 @@ export default function TeacherLesson() {
 
   return (
     <div className="tl-container">
+      <ShootingStars count={16} speed={1} zIndex={-1} />
       <div className="tl-card" aria-busy={loading}>
         <h2 className="tl-title">教案备课</h2>
 


### PR DESCRIPTION
## Summary
- show shooting-star background on teacher lesson page
- use glassy dark headers for teacher tables
- tidy login catch for lint

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0ee92808322aba59a972fa02780