### PR TITLE
feat: suggest follow-up questions on AI teacher page

### DIFF
--- a/backend/routers/student_router.py
+++ b/backend/routers/student_router.py
@@ -20,6 +20,7 @@ from backend.services.chat_service import (
     ask_in_session,
     ask_in_session_stream,
     delete_session,
+    suggest_questions,
 )
 from backend.services.practice_service import (
     generate_practice, list_practices, get_practice, submit_practice,
@@ -62,6 +63,11 @@ def api_list_sessions(user: User = Depends(get_current_user)):
 def api_get_messages(sid: int, user: User = Depends(get_current_user)):
     msgs = get_messages(user.id, sid)
     return [MessageOut(id=m.id, session_id=m.session_id, role=m.role, content=m.content, created_at=m.created_at) for m in msgs]
+
+
+@router.get("/session/{sid}/suggest", response_model=List[str])
+def api_suggest(sid: int, user: User = Depends(get_current_user)):
+    return suggest_questions(user.id, sid)
 
 
 @router.post("/session/{sid}/ask", response_model=MessageOut)

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -195,13 +195,17 @@ def suggest_questions(student_id: int, session_id: int, num: int = 3) -> List[st
             return []
         try:
             data = json.loads(text)
-            if isinstance(data, dict) and "questions" in data:
-                questions = [str(q) for q in data["questions"]]
-            elif isinstance(data, list):
-                questions = [str(q) for q in data]
-            else:
-                raise ValueError
         except Exception:
+            try:
+                import ast
+                data = ast.literal_eval(text)
+            except Exception:
+                data = None
+        if isinstance(data, dict) and "questions" in data:
+            questions = [str(q).strip() for q in data["questions"]]
+        elif isinstance(data, list):
+            questions = [str(q).strip() for q in data]
+        else:
             questions = [
                 line.strip().lstrip("-•").strip()
                 for line in text.splitlines()

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -10,6 +10,7 @@ from backend.utils.deepseek_client import (
 )
 from backend.utils.rag_pipeline import retrieve_from_db
 from datetime import datetime
+import json
 
 def ask_question(student_id: int, question: str) -> ChatHistory:
     resp = call_deepseek_api(question)
@@ -167,6 +168,46 @@ def ask_in_session_stream(
     except Exception:
         sess.close()
         raise
+
+
+def suggest_questions(student_id: int, session_id: int, num: int = 3) -> List[str]:
+    """Generate follow-up questions for a student in a session"""
+    with Session(engine) as sess:
+        session = sess.get(ChatSession, session_id)
+        if not session or session.student_id != student_id:
+            return []
+        msgs = sess.exec(
+            select(ChatMessage)
+            .where(ChatMessage.session_id == session_id)
+            .order_by(ChatMessage.created_at)
+        ).all()
+        conv = [{"role": m.role, "content": m.content} for m in msgs]
+        system_prompt = (
+            "你是一名AI教师助手，请根据对话内容预测学生可能继续提出的学习问题。"
+            "请只返回JSON数组，例如 ['问题1', '问题2', '问题3']。"
+        )
+        conv.insert(0, {"role": "system", "content": system_prompt})
+        conv.append({"role": "user", "content": f"生成{num}个我可能想问的问题。"})
+        try:
+            resp = call_deepseek_api_chat(conv)
+            text = resp["choices"][0]["message"]["content"]
+        except Exception:
+            return []
+        try:
+            data = json.loads(text)
+            if isinstance(data, dict) and "questions" in data:
+                questions = [str(q) for q in data["questions"]]
+            elif isinstance(data, list):
+                questions = [str(q) for q in data]
+            else:
+                raise ValueError
+        except Exception:
+            questions = [
+                line.strip().lstrip("-•").strip()
+                for line in text.splitlines()
+                if line.strip()
+            ]
+        return questions[:num]
 
 
 def delete_session(student_id: int, session_id: int) -> bool:

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -64,7 +64,16 @@ export default function StudentAiTeacher() {
   const fetchHotQuestions = async (sid) => {
     try {
       const r = await api.get(`/student/ai/session/${sid}/suggest`);
-      if (Array.isArray(r.data)) setHotQuestions(r.data);
+      let data = r.data;
+      if (typeof data === "string") {
+        try {
+          const parsed = JSON.parse(data);
+          if (Array.isArray(parsed)) data = parsed;
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      if (Array.isArray(data)) setHotQuestions(data);
     } catch (e) {
       console.error(e);
     }

--- a/frontend/src/pages/StudentAiTeacher.jsx
+++ b/frontend/src/pages/StudentAiTeacher.jsx
@@ -55,11 +55,20 @@ export default function StudentAiTeacher() {
     return processed;
   };
 
-  const hotQuestions = [
+  const [hotQuestions, setHotQuestions] = useState([
     "如何解一元二次方程？",
     "写一首关于夏天的英文诗",
     "什么是 JavaScript 闭包？",
-  ];
+  ]);
+
+  const fetchHotQuestions = async (sid) => {
+    try {
+      const r = await api.get(`/student/ai/session/${sid}/suggest`);
+      if (Array.isArray(r.data)) setHotQuestions(r.data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   // 初始化/加载会话
   useEffect(() => {
@@ -95,6 +104,7 @@ export default function StudentAiTeacher() {
       try {
         const r = await api.get(`/student/ai/session/${current}`);
         setMessages(r.data);
+        fetchHotQuestions(current);
       } catch (e) {
         console.error(e);
       }
@@ -149,6 +159,7 @@ export default function StudentAiTeacher() {
       try {
         const r = await api.get(`/student/ai/session/${current}`);
         setMessages(r.data);
+        fetchHotQuestions(current);
       } catch (e) {
         console.error(e);
       }


### PR DESCRIPTION
## Summary
- generate possible follow-up questions from chat history
- expose endpoint for fetching suggested questions
- load dynamic question suggestions on student AI teacher page

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6f3ddae988322bd1d3d069e1a57f1